### PR TITLE
Create export directories when saving sessions

### DIFF
--- a/mcp_sequential_thinking/storage_utils.py
+++ b/mcp_sequential_thinking/storage_utils.py
@@ -23,8 +23,12 @@ def prepare_thoughts_for_serialization(thoughts: List[ThoughtData]) -> List[Dict
     return [thought.to_dict(include_id=True) for thought in thoughts]
 
 
-def save_thoughts_to_file(file_path: Path, thoughts: List[Dict[str, Any]], 
-                         lock_file: Path, metadata: Dict[str, Any] = None) -> None:
+def save_thoughts_to_file(
+    file_path: Path,
+    thoughts: List[Dict[str, Any]],
+    lock_file: Path,
+    metadata: Dict[str, Any] | None = None,
+) -> None:
     """Save thoughts to a file with proper locking.
 
     Args:
@@ -42,6 +46,10 @@ def save_thoughts_to_file(file_path: Path, thoughts: List[Dict[str, Any]],
     if metadata:
         data.update(metadata)
     
+    # Ensure destination directories exist before acquiring the lock.
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
     # Use file locking to ensure thread safety when writing
     with portalocker.Lock(lock_file, timeout=10) as _:
         with open(file_path, 'w', encoding='utf-8') as f:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -135,6 +135,24 @@ class TestThoughtStorage(unittest.TestCase):
             data = json.load(f)
             self.assertEqual(len(data["thoughts"]), 0)
     
+    def test_export_creates_parent_directory(self):
+        """Test exporting a session to a nested directory creates parents."""
+        thought = ThoughtData(
+            thought="Test thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.CONCLUSION,
+        )
+        self.storage.add_thought(thought)
+
+        nested_dir = Path(self.temp_dir.name) / "exports" / "nested"
+        export_file = nested_dir / "export.json"
+
+        self.storage.export_session(str(export_file))
+
+        self.assertTrue(export_file.exists())
+
     def test_export_import_session(self):
         """Test exporting and importing a session."""
         thought1 = ThoughtData(


### PR DESCRIPTION
## What changed
- ensure exported session files create parent directories before writing
- add coverage for exporting to nested paths

## Why
- exporting to a new nested directory currently fails because the parent path may not exist

## Testing
- ✅ `pytest -q`
