### PR TITLE
Fix audit blockers: path traversal, save race, corrupt-file handling + hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,14 @@
 
 ### Code Quality Improvements
 
-#### 1. Separation of Test Code from Production Code
-- Created a new `testing.py` module for test-specific utilities
-- Implemented conditional test detection using `importlib.util`
-- Improved code clarity by moving test-specific logic out of main modules
-- Enhanced maintainability by clearly separating test and production code paths
-- Replaced hardcoded test strings with named constants
-
-#### 2. Reduced Code Duplication in Storage Layer
+#### 1. Reduced Code Duplication in Storage Layer
 - Created a new `storage_utils.py` module with shared utility functions
 - Implemented reusable functions for file operations and serialization
 - Standardized error handling and backup creation
 - Improved consistency across serialization operations
 - Optimized resource management with cleaner context handling
 
-#### 3. API and Data Structure Improvements
+#### 2. API and Data Structure Improvements
 - Added explicit parameter for ID inclusion in `to_dict()` method
 - Created utility module with snake_case/camelCase conversion functions
 - Eliminated flag-based solution in favor of explicit method parameters

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ A Model Context Protocol (MCP) server that facilitates structured, progressive t
 - **Pydantic**: For data validation and serialization
 - **Portalocker**: For thread-safe file access
 - **FastMCP**: For Model Context Protocol integration
-- **Rich**: For enhanced console output
-- **PyYAML**: For configuration management
 
 ## Project Structure
 
@@ -169,8 +167,6 @@ If you've installed the package globally with `pip install -e .`:
       "args": [
         "--from",
         "git+https://github.com/arben-adm/mcp-sequential-thinking",
-        "--with",
-        "portalocker",
         "mcp-sequential-thinking"
       ]
     }
@@ -308,8 +304,6 @@ Add to your Gemini CLI settings at `~/.gemini/settings.json`:
       "args": [
         "--from",
         "git+https://github.com/arben-adm/mcp-sequential-thinking",
-        "--with",
-        "portalocker",
         "mcp-sequential-thinking"
       ],
       "env": {}

--- a/mcp_sequential_thinking/analysis.py
+++ b/mcp_sequential_thinking/analysis.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from datetime import datetime
 from typing import Any, Dict, List
 
 from .logging_conf import configure_logging

--- a/mcp_sequential_thinking/models.py
+++ b/mcp_sequential_thinking/models.py
@@ -1,8 +1,8 @@
-from typing import List, Optional, Dict, Any
+from typing import List
 from enum import Enum
 from datetime import datetime
 from uuid import uuid4, UUID
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, ValidationInfo
 
 
 class ThoughtStage(Enum):
@@ -49,17 +49,18 @@ class ThoughtData(BaseModel):
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
     id: UUID = Field(default_factory=uuid4)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Make ThoughtData hashable based on its ID."""
         return hash(self.id)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """Compare ThoughtData objects based on their ID."""
         if not isinstance(other, ThoughtData):
             return False
         return self.id == other.id
 
     @field_validator('thought')
+    @classmethod
     def thought_not_empty(cls, v: str) -> str:
         """Validate that thought content is not empty."""
         if not v or not v.strip():
@@ -67,6 +68,7 @@ class ThoughtData(BaseModel):
         return v
 
     @field_validator('thought_number')
+    @classmethod
     def thought_number_positive(cls, v: int) -> int:
         """Validate that thought number is positive."""
         if v < 1:
@@ -74,71 +76,40 @@ class ThoughtData(BaseModel):
         return v
 
     @field_validator('total_thoughts')
-    def total_thoughts_valid(cls, v: int, values: Dict[str, Any]) -> int:
+    @classmethod
+    def total_thoughts_valid(cls, v: int, info: ValidationInfo) -> int:
         """Validate that total thoughts is valid."""
-        thought_number = values.data.get('thought_number')
+        thought_number = info.data.get('thought_number')
         if thought_number is not None and v < thought_number:
             raise ValueError("Total thoughts must be greater or equal to current thought number")
         return v
-
-    def validate(self) -> bool:
-        """Legacy validation method for backward compatibility.
-
-        Returns:
-            bool: True if the thought data is valid
-
-        Raises:
-            ValueError: If any validation checks fail
-        """
-        # Validation is now handled by Pydantic automatically
-        return True
 
     def to_dict(self, include_id: bool = False) -> dict:
         """Convert the thought data to a dictionary representation.
 
         Args:
             include_id: Whether to include the ID in the dictionary representation.
-                        Default is False to maintain compatibility with tests.
+                        Default is False to omit it from external representations.
 
         Returns:
-            dict: Dictionary representation of the thought data
+            dict: Dictionary representation of the thought data, with camelCase
+                keys for API consistency.
         """
-        from .utils import to_camel_case
+        result = {
+            "thought": self.thought,
+            "thoughtNumber": self.thought_number,
+            "totalThoughts": self.total_thoughts,
+            "nextThoughtNeeded": self.next_thought_needed,
+            "stage": self.stage.value,
+            "tags": self.tags,
+            "axiomsUsed": self.axioms_used,
+            "assumptionsChallenged": self.assumptions_challenged,
+            "timestamp": self.timestamp,
+        }
 
-        # Get all model fields, excluding internal properties
-        data = self.model_dump()
-        
-        # Handle special conversions
-        data["stage"] = self.stage.value
-        
-        if not include_id:
-            # Remove ID for external representations
-            data.pop("id", None)
-        else:
-            # Convert ID to string for JSON serialization
-            data["id"] = str(data["id"])
-        
-        # Convert snake_case keys to camelCase for API consistency
-        result = {}
-        for key, value in data.items():
-            if key == "stage":
-                # Stage is already handled above
-                continue
-                
-            camel_key = to_camel_case(key)
-            result[camel_key] = value
-        
-        # Ensure these fields are always present with camelCase naming
-        result["thought"] = self.thought
-        result["thoughtNumber"] = self.thought_number
-        result["totalThoughts"] = self.total_thoughts
-        result["nextThoughtNeeded"] = self.next_thought_needed
-        result["stage"] = self.stage.value
-        result["tags"] = self.tags
-        result["axiomsUsed"] = self.axioms_used
-        result["assumptionsChallenged"] = self.assumptions_challenged
-        result["timestamp"] = self.timestamp
-        
+        if include_id:
+            result["id"] = str(self.id)
+
         return result
 
     @classmethod
@@ -151,8 +122,6 @@ class ThoughtData(BaseModel):
         Returns:
             ThoughtData: A new ThoughtData instance
         """
-        from .utils import to_snake_case
-        
         # Convert any camelCase keys to snake_case
         snake_data = {}
         mappings = {

--- a/mcp_sequential_thinking/server.py
+++ b/mcp_sequential_thinking/server.py
@@ -28,15 +28,15 @@ storage = ThoughtStorage(storage_dir)
 
 
 @mcp.tool()
-def process_thought(
+async def process_thought(
     thought: str,
     thought_number: int,
     total_thoughts: int,
     next_thought_needed: bool,
     stage: str,
-    tags: List[str] = [],
-    axioms_used: List[str] = [],
-    assumptions_challenged: List[str] = [],
+    tags: Optional[List[str]] = None,
+    axioms_used: Optional[List[str]] = None,
+    assumptions_challenged: Optional[List[str]] = None,
     ctx: Optional[Context] = None,
 ) -> dict:
     """Add a sequential thought with its metadata.
@@ -55,13 +55,18 @@ def process_thought(
     Returns:
         dict: Analysis of the processed thought
     """
+    # Normalize optional list arguments (avoid mutable default arguments).
+    tags = tags or []
+    axioms_used = axioms_used or []
+    assumptions_challenged = assumptions_challenged or []
+
     try:
         # Log the request
         logger.info(f"Processing thought #{thought_number}/{total_thoughts} in stage '{stage}'")
 
         # Report progress if context is available
         if ctx:
-            ctx.report_progress(thought_number - 1, total_thoughts)
+            await ctx.report_progress(thought_number - 1, total_thoughts)
 
         # Convert stage string to enum
         thought_stage = ThoughtStage.from_string(stage)
@@ -78,8 +83,7 @@ def process_thought(
             assumptions_challenged=assumptions_challenged,
         )
 
-        # Validate and store
-        thought_data.validate()
+        # Store (validation already happened during ThoughtData construction)
         storage.add_thought(thought_data)
 
         # Get all thoughts for analysis

--- a/mcp_sequential_thinking/storage.py
+++ b/mcp_sequential_thinking/storage.py
@@ -1,12 +1,7 @@
-import json
-import logging
-import os
 import threading
-from typing import List, Optional, Dict, Any
+from typing import List, Optional
 from pathlib import Path
 from datetime import datetime
-
-import portalocker
 
 from .models import ThoughtData, ThoughtStage
 from .logging_conf import configure_logging
@@ -45,21 +40,62 @@ class ThoughtStorage:
         # Load existing session if available
         self._load_session()
 
+    @staticmethod
+    def _ensure_within(base: Path, candidate: str) -> Path:
+        """Resolve ``candidate`` and ensure it stays inside ``base``.
+
+        Confines model-controlled export/import paths to the storage directory
+        so a path like ``/etc/passwd`` or ``../../foo`` cannot escape it
+        (CWE-22 / CWE-73).
+
+        Args:
+            base: The directory the path must stay within (e.g. storage_dir).
+            candidate: The caller-supplied path (may be absolute or relative).
+
+        Returns:
+            Path: The resolved, contained path (safe to open).
+
+        Raises:
+            ValueError: If the resolved path is outside ``base``.
+        """
+        base_r = base.resolve()
+        candidate_path = Path(candidate)
+        if candidate_path.is_absolute():
+            resolved = candidate_path.resolve()
+        else:
+            resolved = (base_r / candidate_path).resolve()
+
+        try:
+            resolved.relative_to(base_r)
+        except ValueError:
+            raise ValueError(
+                f"Path '{candidate}' is outside the allowed storage directory "
+                f"'{base_r}'. Export/import are confined to the storage directory."
+            )
+        return resolved
+
     def _load_session(self) -> None:
         """Load thought history from the current session file if it exists."""
         with self._lock:
-            # Use the utility function to handle loading with proper error handling
-            self.thought_history = load_thoughts_from_file(self.current_session_file, self.lock_file)
+            # Use the utility function to handle loading with proper error handling.
+            # backup_on_corruption=True: this is our own session file, so a corrupt
+            # or invalid file is backed up and we recover with an empty session
+            # rather than crashing the server on startup.
+            self.thought_history = load_thoughts_from_file(
+                self.current_session_file, self.lock_file, backup_on_corruption=True
+            )
 
     def _save_session(self) -> None:
         """Save the current thought history to the session file."""
-        # Use thread lock to ensure consistent data
+        # Use thread lock to ensure consistent data. Snapshot AND file write
+        # must both run under the lock so a stale snapshot can never be written
+        # after a newer one (RLock makes reentrancy harmless).
         with self._lock:
             # Use utility functions to prepare and save thoughts
             thoughts_with_ids = prepare_thoughts_for_serialization(self.thought_history)
-        
-        # Save to file with proper locking
-        save_thoughts_to_file(self.current_session_file, thoughts_with_ids, self.lock_file)
+
+            # Save to file with proper locking
+            save_thoughts_to_file(self.current_session_file, thoughts_with_ids, self.lock_file)
 
     def add_thought(self, thought: ThoughtData) -> None:
         """Add a thought to the history and save the session.
@@ -103,8 +139,15 @@ class ThoughtStorage:
         """Export the current session to a file.
 
         Args:
-            file_path: Path to save the exported session
+            file_path: Path to save the exported session. Must resolve to a
+                location inside the storage directory.
+
+        Raises:
+            ValueError: If file_path resolves outside the storage directory.
         """
+        # Confine the caller-controlled path to storage_dir before any file I/O.
+        file_path_obj = self._ensure_within(self.storage_dir, file_path)
+
         with self._lock:
             # Use utility function to prepare thoughts for serialization
             thoughts_with_ids = prepare_thoughts_for_serialization(self.thought_history)
@@ -121,10 +164,8 @@ class ThoughtStorage:
                 }
             }
         
-        # Convert string path to Path object for compatibility with utility
-        file_path_obj = Path(file_path)
         lock_file = file_path_obj.with_suffix('.lock')
-        
+
         # Use utility function to save with proper locking
         save_thoughts_to_file(file_path_obj, thoughts_with_ids, lock_file, metadata)
 
@@ -135,17 +176,22 @@ class ThoughtStorage:
             file_path: Path to the file to import
 
         Raises:
-            FileNotFoundError: If the file doesn't exist
-            json.JSONDecodeError: If the file is not valid JSON
-            KeyError: If the file doesn't contain valid thought data
+            ValueError: If file_path resolves outside the storage directory,
+                if the file is not valid JSON, or if it contains semantically
+                invalid thought data. In all error cases the input file and the
+                current session are left untouched.
+            FileNotFoundError: If the file doesn't exist.
+            KeyError: If the file doesn't contain valid thought data.
         """
-        # Convert string path to Path object for compatibility with utility
-        file_path_obj = Path(file_path)
+        # Confine the caller-controlled path to storage_dir before any file I/O.
+        file_path_obj = self._ensure_within(self.storage_dir, file_path)
         lock_file = file_path_obj.with_suffix('.lock')
-        
-        # Use utility function to load thoughts with proper error handling
+
+        # Use utility function to load thoughts. backup_on_corruption defaults to
+        # False, so a malformed/invalid input file raises instead of renaming the
+        # caller's file or silently wiping the current session.
         thoughts = load_thoughts_from_file(file_path_obj, lock_file)
-        
+
         with self._lock:
             self.thought_history = thoughts
 

--- a/mcp_sequential_thinking/storage_utils.py
+++ b/mcp_sequential_thinking/storage_utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from typing import List, Dict, Any
 from pathlib import Path
 from datetime import datetime
@@ -50,50 +51,82 @@ def save_thoughts_to_file(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     lock_file.parent.mkdir(parents=True, exist_ok=True)
 
+    # Write atomically: dump to a temp file in the same directory, fsync, then
+    # os.replace() onto the target. This guarantees the destination is always
+    # either the old or the new complete state, never a truncated half-write.
+    tmp_path = file_path.with_suffix(file_path.suffix + '.tmp')
+
     # Use file locking to ensure thread safety when writing
     with portalocker.Lock(lock_file, timeout=10) as _:
-        with open(file_path, 'w', encoding='utf-8') as f:
+        with open(tmp_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
-            
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, file_path)
+
     logger.debug(f"Saved {len(thoughts)} thoughts to {file_path}")
 
 
-def load_thoughts_from_file(file_path: Path, lock_file: Path) -> List[ThoughtData]:
+def load_thoughts_from_file(
+    file_path: Path,
+    lock_file: Path,
+    backup_on_corruption: bool = False,
+) -> List[ThoughtData]:
     """Load thoughts from a file with proper locking.
 
     Args:
         file_path: Path to the file to load
         lock_file: Path to the lock file
+        backup_on_corruption: Recovery behaviour reserved for the server's own
+            session file. When True, a corrupt or semantically invalid file is
+            renamed to a ``.bak.<timestamp>`` backup and an empty list is
+            returned (the server stays up). When False (the default, used for
+            ``import_session``), any parse/validation error propagates so the
+            caller's input file and current state are left untouched.
 
     Returns:
         List[ThoughtData]: Loaded thought data objects
-        
+
     Raises:
-        json.JSONDecodeError: If the file is not valid JSON
-        KeyError: If the file doesn't contain valid thought data
+        json.JSONDecodeError: If the file is not valid JSON (only when
+            ``backup_on_corruption`` is False).
+        KeyError: If the file doesn't contain valid thought data (only when
+            ``backup_on_corruption`` is False).
+        ValueError: If the file contains semantically invalid data, e.g. an
+            unknown stage or a failed model validation (only when
+            ``backup_on_corruption`` is False). Note that ``JSONDecodeError``
+            and ``pydantic.ValidationError`` are both ``ValueError`` subclasses.
     """
     if not file_path.exists():
         return []
-        
+
     try:
         # Use file locking and file handling in a single with statement
         # for cleaner resource management
         with portalocker.Lock(lock_file, timeout=10) as _, open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
-        
+
         # Convert data to ThoughtData objects after file is closed
         thoughts = [
             ThoughtData.from_dict(thought_dict)
             for thought_dict in data.get("thoughts", [])
         ]
-            
+
         logger.debug(f"Loaded {len(thoughts)} thoughts from {file_path}")
         return thoughts
-        
-    except (json.JSONDecodeError, KeyError) as e:
-        # Handle corrupted file
+
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
+        # JSONDecodeError and pydantic.ValidationError are ValueError subclasses,
+        # so (KeyError, ValueError) covers malformed JSON, missing keys, unknown
+        # stages and failed model validation alike.
         logger.error(f"Error loading from {file_path}: {e}")
-        # Create backup of corrupted file
+
+        if not backup_on_corruption:
+            # Import path: never touch the caller's file or our current state.
+            raise
+
+        # Recovery path (own session file only): back up the corrupt file and
+        # start from an empty session instead of crashing the server.
         backup_file = file_path.with_suffix(f".bak.{datetime.now().strftime('%Y%m%d%H%M%S')}")
         file_path.rename(backup_file)
         logger.info(f"Created backup of corrupted file at {backup_file}")

--- a/mcp_sequential_thinking/utils.py
+++ b/mcp_sequential_thinking/utils.py
@@ -3,66 +3,15 @@
 This module contains common utilities used across the package.
 """
 
-import re
-from typing import Dict, Any
-
-
 def to_camel_case(snake_str: str) -> str:
     """Convert a snake_case string to camelCase.
-    
+
     Args:
         snake_str: A string in snake_case format
-        
+
     Returns:
         The string converted to camelCase
     """
     components = snake_str.split('_')
     # Join with the first component lowercase and the rest with their first letter capitalized
     return components[0] + ''.join(x.title() for x in components[1:])
-
-
-def to_snake_case(camel_str: str) -> str:
-    """Convert a camelCase string to snake_case.
-    
-    Args:
-        camel_str: A string in camelCase format
-        
-    Returns:
-        The string converted to snake_case
-    """
-    # Insert underscore before uppercase letters and convert to lowercase
-    s1 = re.sub(r'(.)([A-Z][a-z]+)', r'\1_\2', camel_str)
-    return re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
-
-
-def convert_dict_keys(data: Dict[str, Any], converter: callable) -> Dict[str, Any]:
-    """Convert all keys in a dictionary using the provided converter function.
-    
-    Args:
-        data: Dictionary with keys to convert
-        converter: Function to convert the keys (e.g. to_camel_case or to_snake_case)
-        
-    Returns:
-        A new dictionary with converted keys
-    """
-    if not isinstance(data, dict):
-        return data
-        
-    result = {}
-    for key, value in data.items():
-        # Convert key
-        new_key = converter(key)
-        
-        # If value is a dict, recursively convert its keys too
-        if isinstance(value, dict):
-            result[new_key] = convert_dict_keys(value, converter)
-        # If value is a list, check if items are dicts and convert them
-        elif isinstance(value, list):
-            result[new_key] = [
-                convert_dict_keys(item, converter) if isinstance(item, dict) else item
-                for item in value
-            ]
-        else:
-            result[new_key] = value
-            
-    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ authors = [
 dependencies = [
    "mcp[cli]>=1.2.0",
    "pydantic>=2.0.0",
-   "rich>=13.7.0",
-   "pyyaml>=6.0",
    "portalocker",
 ]
 
@@ -44,7 +42,7 @@ all = [
 ]
 
 [project.urls]
-Source = "https://github.com/arben-adm/sequential-thinking"
+Source = "https://github.com/arben-adm/mcp-sequential-thinking"
 
 [tool.hatch.build.targets.wheel]
 packages = ["mcp_sequential_thinking"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ class TestThoughtData(unittest.TestCase):
     """Test cases for the ThoughtData class."""
 
     def test_validate_valid(self):
-        """Test validation of valid thought data."""
+        """Test that valid thought data is accepted at construction time."""
         thought = ThoughtData(
             thought="Test thought",
             thought_number=1,
@@ -33,7 +33,11 @@ class TestThoughtData(unittest.TestCase):
             next_thought_needed=True,
             stage=ThoughtStage.PROBLEM_DEFINITION
         )
-        self.assertTrue(thought.validate())
+        # Validation is handled by Pydantic during construction; a successfully
+        # constructed instance is valid.
+        self.assertEqual(thought.thought, "Test thought")
+        self.assertEqual(thought.thought_number, 1)
+        self.assertEqual(thought.total_thoughts, 3)
 
     def test_validate_invalid_thought_number(self):
         """Test validation fails with invalid thought number."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,62 @@
+import asyncio
+import os
+import tempfile
+import unittest
+
+
+class TestProcessThought(unittest.TestCase):
+    """Test cases for the process_thought server tool."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Point storage at a throwaway directory before importing the server,
+        # since the module creates a ThoughtStorage at import time.
+        cls._tmp = tempfile.TemporaryDirectory()
+        os.environ["MCP_STORAGE_DIR"] = cls._tmp.name
+        from mcp_sequential_thinking import server  # noqa: E402
+        cls.server = server
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+        os.environ.pop("MCP_STORAGE_DIR", None)
+
+    def setUp(self):
+        self.server.storage.clear_history()
+
+    def test_process_thought_returns_analysis(self):
+        """Awaiting process_thought (ctx=None) returns analysis without raising
+        or emitting an unawaited-coroutine RuntimeWarning."""
+        result = asyncio.run(
+            self.server.process_thought(
+                thought="A first thought",
+                thought_number=1,
+                total_thoughts=2,
+                next_thought_needed=True,
+                stage="Analysis",
+                ctx=None,
+            )
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("thoughtAnalysis", result)
+
+    def test_process_thought_omitting_optional_lists(self):
+        """Calling without the optional list args still returns analysis
+        (regression for mutable-default replacement)."""
+        result = asyncio.run(
+            self.server.process_thought(
+                thought="Another thought",
+                thought_number=1,
+                total_thoughts=1,
+                next_thought_needed=False,
+                stage="Conclusion",
+            )
+        )
+
+        self.assertIsInstance(result, dict)
+        self.assertIn("thoughtAnalysis", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,6 +2,7 @@ import unittest
 import tempfile
 import json
 import os
+import threading
 from pathlib import Path
 
 from mcp_sequential_thinking.models import ThoughtStage, ThoughtData
@@ -189,6 +190,167 @@ class TestThoughtStorage(unittest.TestCase):
         self.assertEqual(len(self.storage.thought_history), 2)
         self.assertEqual(self.storage.thought_history[0].thought, "Test thought 1")
         self.assertEqual(self.storage.thought_history[1].thought, "Test thought 2")
+
+    # ------------------------------------------------------------------
+    # T1: race in _save_session — disk must match memory under concurrency
+    # ------------------------------------------------------------------
+    def test_concurrent_add_clear_disk_matches_memory(self):
+        """Concurrent add_thought + clear_history must never leave a stale
+        snapshot on disk (regression for the _save_session race)."""
+        session_file = Path(self.temp_dir.name) / "current_session.json"
+        mismatches = 0
+
+        for _ in range(200):
+            with tempfile.TemporaryDirectory() as d:
+                storage = ThoughtStorage(d)
+                sfile = Path(d) / "current_session.json"
+
+                thought = ThoughtData(
+                    thought="Concurrent thought",
+                    thought_number=1,
+                    total_thoughts=1,
+                    next_thought_needed=False,
+                    stage=ThoughtStage.ANALYSIS,
+                )
+
+                t_add = threading.Thread(target=storage.add_thought, args=(thought,))
+                t_clear = threading.Thread(target=storage.clear_history)
+
+                t_add.start()
+                t_clear.start()
+                t_add.join()
+                t_clear.join()
+
+                with open(sfile, "r", encoding="utf-8") as f:
+                    disk_len = len(json.load(f)["thoughts"])
+
+                if disk_len != len(storage.thought_history):
+                    mismatches += 1
+
+        self.assertEqual(mismatches, 0, f"{mismatches}/200 disk/memory mismatches")
+        # Silence unused-variable linters; session_file documents intent.
+        del session_file
+
+    # ------------------------------------------------------------------
+    # T2: failed import must not rename foreign file or wipe session
+    # ------------------------------------------------------------------
+    def test_import_invalid_file_raises_and_preserves_state(self):
+        """Importing a non-JSON file raises and leaves both the input file and
+        the current session untouched."""
+        thought = ThoughtData(
+            thought="Existing thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.PROBLEM_DEFINITION,
+        )
+        self.storage.add_thought(thought)
+        self.assertEqual(len(self.storage.thought_history), 1)
+
+        # A plain text file inside the storage dir (passes containment, fails parse).
+        notes = Path(self.temp_dir.name) / "notes.txt"
+        notes.write_text("just some notes, not json", encoding="utf-8")
+
+        with self.assertRaises(ValueError):
+            self.storage.import_session(str(notes))
+
+        # Input file unchanged, not renamed.
+        self.assertTrue(notes.exists())
+        self.assertEqual(notes.read_text(encoding="utf-8"), "just some notes, not json")
+        self.assertEqual(list(Path(self.temp_dir.name).glob("notes.bak.*")), [])
+
+        # Current session unchanged in memory and on disk.
+        self.assertEqual(len(self.storage.thought_history), 1)
+        session_file = Path(self.temp_dir.name) / "current_session.json"
+        with open(session_file, "r", encoding="utf-8") as f:
+            self.assertEqual(len(json.load(f)["thoughts"]), 1)
+
+    # ------------------------------------------------------------------
+    # T3: server start recovers from semantically corrupt session file
+    # ------------------------------------------------------------------
+    def test_init_with_invalid_stage_recovers(self):
+        """A session file with an invalid stage must not crash startup; it is
+        backed up and recovery starts from an empty session."""
+        with tempfile.TemporaryDirectory() as d:
+            session_file = Path(d) / "current_session.json"
+            session_file.write_text(
+                json.dumps({"thoughts": [{"thought": "x", "stage": "Brainstorm"}]}),
+                encoding="utf-8",
+            )
+
+            storage = ThoughtStorage(d)  # must not raise
+
+            self.assertEqual(storage.thought_history, [])
+            backups = list(Path(d).glob("current_session.bak.*"))
+            self.assertEqual(len(backups), 1)
+
+    # ------------------------------------------------------------------
+    # T4: export/import confined to storage_dir (CWE-22)
+    # ------------------------------------------------------------------
+    def test_export_rejects_path_outside_storage(self):
+        """Exporting outside storage_dir is rejected and creates nothing."""
+        thought = ThoughtData(
+            thought="Test thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.CONCLUSION,
+        )
+        self.storage.add_thought(thought)
+
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "sub" / "owned.json"
+            lock = Path(outside) / "sub" / "owned.lock"
+
+            # Absolute path outside storage_dir.
+            with self.assertRaises(ValueError):
+                self.storage.export_session(str(target))
+            self.assertFalse(target.exists())
+            self.assertFalse(lock.exists())
+            self.assertFalse(target.parent.exists())
+
+            # '..' traversal escaping storage_dir.
+            traversal = os.path.join(self.temp_dir.name, "..", "escape.json")
+            with self.assertRaises(ValueError):
+                self.storage.export_session(traversal)
+            self.assertFalse(Path(traversal).resolve().exists())
+
+    def test_import_rejects_path_outside_storage(self):
+        """Importing from outside storage_dir is rejected and creates nothing."""
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "payload.json"
+            target.write_text(json.dumps({"thoughts": []}), encoding="utf-8")
+            lock = Path(outside) / "payload.lock"
+
+            with self.assertRaises(ValueError):
+                self.storage.import_session(str(target))
+            self.assertFalse(lock.exists())
+
+            traversal = os.path.join(self.temp_dir.name, "..", "escape.json")
+            with self.assertRaises(ValueError):
+                self.storage.import_session(traversal)
+
+    # ------------------------------------------------------------------
+    # T7: atomic write leaves no temp file behind
+    # ------------------------------------------------------------------
+    def test_save_is_atomic_no_tmp_leftover(self):
+        """After saving, no *.tmp file remains and the session file is valid JSON."""
+        thought = ThoughtData(
+            thought="Test thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.ANALYSIS,
+        )
+        self.storage.add_thought(thought)
+
+        leftovers = list(Path(self.temp_dir.name).glob("*.tmp"))
+        self.assertEqual(leftovers, [])
+
+        session_file = Path(self.temp_dir.name) / "current_session.json"
+        with open(session_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(len(data["thoughts"]), 1)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1040,11 +1040,12 @@ wheels = [
 
 [[package]]
 name = "sequential-thinking"
-version = "0.3.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "portalocker" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
 ]
@@ -1057,7 +1058,6 @@ all = [
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "numpy" },
-    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "uvicorn" },
@@ -1075,7 +1075,6 @@ vis = [
 ]
 web = [
     { name = "fastapi" },
-    { name = "pydantic" },
     { name = "uvicorn" },
 ]
 
@@ -1089,7 +1088,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "numpy", marker = "extra == 'vis'", specifier = ">=1.20.0" },
     { name = "portalocker" },
-    { name = "pydantic", marker = "extra == 'web'", specifier = ">=2.0.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
This branch addresses the findings from a full code/security audit (tasks T1–T11), with new tests for every blocker.

Fixes #17

## Security

**Path traversal in `export_session` / `import_session` (CWE-22 / CWE-73) — #17**
Both tools passed a caller-controlled `file_path` straight to file I/O, allowing arbitrary file write/read, lock-file creation anywhere, and directory auto-creation outside the storage dir. Added `ThoughtStorage._ensure_within()`, which resolves the path and rejects anything outside `storage_dir` **before any I/O**. Absolute paths, `..` traversal and out-of-tree imports now raise `ValueError`, which the server surfaces as a structured `{"error", "status": "failed"}` response. Export/import are confined to `storage_dir`. Verified against the reporters PoC: the target file, its `.lock`, and the auto-created directory are no longer produced.

## Other blockers

- **Save race (`_save_session`):** the file write ran outside the lock, so a stale snapshot could overwrite a newer one (~13% disk/memory divergence under concurrency). Snapshot and write are now atomic under the same lock.
- **Destructive failed import:** a failed `import_session` renamed the callers file and silently wiped the current session. Corruption-recovery (backup + rename) is now opt-in and limited to the servers own session file; the import path re-raises and leaves both the input file and current session untouched.
- **Crash on corrupt session file at startup:** the loader only caught `(JSONDecodeError, KeyError)`, so a semantically invalid session file (bad stage / missing field) crashed the server on boot. It now also handles `ValueError` and recovers with a backup instead of crashing.

## Important / quality

- **`report_progress`:** `process_thought` is now `async` and awaits `ctx.report_progress`, so progress is actually sent and no unawaited-coroutine `RuntimeWarning` is raised.
- **Atomic writes:** session files are written via a temp file + `fsync` + `os.replace`, so the destination is always a complete old/new state.
- **Pydantic v2:** field validators use `@classmethod`; `total_thoughts_valid` takes `ValidationInfo` instead of a mis-annotated `Dict` (clean under `mypy`).
- **Packaging:** corrected the `Source` URL; dropped unused `rich` / `pyyaml` dependencies.
- **Cleanup:** removed mutable default arguments, dead imports, the no-op legacy `validate()`, and unused utils; simplified `to_dict`; aligned CHANGELOG and README.

## Verification

- `pytest` — 27 passed (8 new tests: concurrency, import safety, startup recovery, path-traversal rejection, atomic write, async server tool), also clean under `-W error::RuntimeWarning`.
- `mypy mcp_sequential_thinking/models.py` — no issues.
- Server starts without traceback; no `rich` / `yaml` imports remain.