### PR TITLE
v0.6.0: revisions & branching, JSONL session format (schema v2), PyPI rename, import/export hardening, CI/release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]"
+      - run: pytest tests/ -v
+      - run: mypy mcp_sequential_thinking/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - run: pip install build && python -m build
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@
 - **Package renamed** from `sequential-thinking` to `mcp-sequential-thinking` for the PyPI
   release (the old name is occupied by a third-party fork). The console script
   `mcp-sequential-thinking` and the import package `mcp_sequential_thinking` are unchanged.
+- **Breaking:** `export_session` and `import_session` are now confined to the
+  `exports/` subdirectory of the storage directory (relative paths resolve to
+  `~/.mcp_sequential_thinking/exports/` by default). This prevents an export from
+  overwriting the active session file or its lock file.
 
 ### Fixed
+- `import_session` no longer silently replaces the active session with an empty
+  one when the given file is a valid JSON file without a `thoughts` key, or when
+  the file does not exist. Both cases now raise and leave the session untouched.
+- Path-validation errors returned to the MCP client no longer leak the absolute
+  storage path (e.g. the user's home directory); the full path is only logged
+  server-side.
 - `mypy` now passes cleanly: added missing type annotations in `analysis.py`
   (`stages`, `percent_complete`) and `server.py` (`main() -> None`), and removed
   duplicate `import os` / `import sys` in the `__main__` block of `server.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.0] - Unreleased
+
+### Changed
+- **Package renamed** from `sequential-thinking` to `mcp-sequential-thinking` for the PyPI
+  release (the old name is occupied by a third-party fork). The console script
+  `mcp-sequential-thinking` and the import package `mcp_sequential_thinking` are unchanged.
+
+### Fixed
+- `mypy` now passes cleanly: added missing type annotations in `analysis.py`
+  (`stages`, `percent_complete`) and `server.py` (`main() -> None`), and removed
+  duplicate `import os` / `import sys` in the `__main__` block of `server.py`.
+
 ## Version 0.5.0 (Unreleased)
 
 ### Code Quality Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [0.6.0] - Unreleased
 
 ### Added
+- **Append-only JSONL session format (schema v2)**: the session now lives in
+  `current_session.jsonl` (header record + one thought per line). `process_thought`
+  is O(1) per call instead of rewriting the full history, and the file doubles as
+  an audit trail. A truncated final line (interrupted write) is dropped on load
+  instead of invalidating the whole session. Existing v1 `current_session.json`
+  files are migrated automatically and losslessly on first start; the original is
+  kept as `current_session.json.migrated-to-v2`.
+- JSON exports now carry a top-level `"version": 2` field. Legacy v0.5.0 exports
+  (no version field) remain importable.
 - CI workflow (GitHub Actions): test matrix on Linux/Windows with Python 3.10
   and 3.12, running pytest and mypy on every push and pull request.
 - Dependabot configuration for pip and GitHub Actions dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [0.6.0] - Unreleased
 
+### Added
+- CI workflow (GitHub Actions): test matrix on Linux/Windows with Python 3.10
+  and 3.12, running pytest and mypy on every push and pull request.
+- Dependabot configuration for pip and GitHub Actions dependencies.
+- `SECURITY.md` with a private disclosure contact.
+
 ### Changed
 - **Package renamed** from `sequential-thinking` to `mcp-sequential-thinking` for the PyPI
   release (the old name is occupied by a third-party fork). The console script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   (no version field) remain importable.
 - CI workflow (GitHub Actions): test matrix on Linux/Windows with Python 3.10
   and 3.12, running pytest and mypy on every push and pull request.
+- Release workflow publishing to PyPI via Trusted Publishing when a GitHub
+  release is published (requires one-time Trusted Publisher setup on pypi.org).
 - Dependabot configuration for pip and GitHub Actions dependencies.
 - `SECURITY.md` with a private disclosure contact.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [0.6.0] - Unreleased
 
 ### Added
+- **Thought revisions and branching**: `process_thought` accepts new optional
+  parameters `is_revision`, `revises_thought_number`, `branch_from_thought` and
+  `branch_id` to revise an earlier thought or fork an alternative line of
+  reasoning. Cross-field validation enforces consistent usage. Analysis output
+  reports `isRevision`/`revisedThought`/`branchId` (plus a `revisionOf` snippet
+  for revisions), and `generate_summary` gains a `branches` object and a
+  `revisionCount`. Progress metrics are based on mainline thoughts only, so
+  revisions and branches no longer inflate completion beyond 100%.
 - **Append-only JSONL session format (schema v2)**: the session now lives in
   `current_session.jsonl` (header record + one thought per line). `process_thought`
   is O(1) per call instead of rewriting the full history, and the file doubles as

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ A Model Context Protocol (MCP) server that facilitates structured, progressive t
 ## Features
 
 - **Structured Thinking Framework**: Organizes thoughts through standard cognitive stages (Problem Definition, Research, Analysis, Synthesis, Conclusion)
+- **Revisions & Branching**: Revise earlier thoughts or fork alternative lines of reasoning, with revision- and branch-aware analysis and summaries
 - **Thought Tracking**: Records and manages sequential thoughts with metadata
 - **Related Thought Analysis**: Identifies connections between similar thoughts
 - **Progress Monitoring**: Tracks your position in the overall thinking sequence
 - **Summary Generation**: Creates concise overviews of the entire thought process
-- **Persistent Storage**: Automatically saves your thinking sessions with thread-safety
+- **Persistent Storage**: Append-only JSONL session log with thread-safety and automatic crash recovery
 - **Data Import/Export**: Share and reuse thinking sessions
 - **Extensible Architecture**: Easily customize and extend functionality
 - **Robust Error Handling**: Graceful handling of edge cases and corrupted data
@@ -333,6 +334,8 @@ Add to your Gemini CLI settings at `~/.gemini/settings.json`:
 
 The server maintains a history of thoughts and processes them through a structured workflow. Each thought is validated using Pydantic models, categorized into thinking stages, and stored with relevant metadata in a thread-safe storage system. The server automatically handles data persistence, backup creation, and provides tools for analyzing relationships between thoughts.
 
+Sessions are persisted as an append-only JSONL log at `~/.mcp_sequential_thinking/current_session.jsonl` (override the directory with the `MCP_STORAGE_DIR` environment variable). Each `process_thought` call appends a single fsynced line, so the file doubles as an audit trail and a truncated final line from an interrupted write is recovered automatically. Sessions from v0.5.x (`current_session.json`) are migrated losslessly on first start; the original file is kept as `current_session.json.migrated-to-v2`.
+
 ## Usage Guide
 
 The Sequential Thinking server exposes five main tools:
@@ -356,6 +359,10 @@ Records and analyzes a new thought in your sequential thinking process.
 - `tags` (list of strings, optional): Keywords or categories for your thought
 - `axioms_used` (list of strings, optional): Principles or axioms applied in your thought
 - `assumptions_challenged` (list of strings, optional): Assumptions your thought questions or challenges
+- `is_revision` (boolean, optional): Whether this thought revises an earlier one
+- `revises_thought_number` (integer, optional): The number of the earlier thought being revised (required together with `is_revision`)
+- `branch_from_thought` (integer, optional): The thought number to fork from when exploring an alternative path
+- `branch_id` (string, optional): Identifier for the branch (letters, digits, `-`, `_`; max 64 characters; requires `branch_from_thought`)
 
 **Example:**
 
@@ -370,6 +377,28 @@ process_thought(
     tags=["climate", "global policy", "systems thinking"],
     axioms_used=["Complex problems require multifaceted solutions"],
     assumptions_challenged=["Technology alone can solve climate change"]
+)
+
+# Revise an earlier thought
+process_thought(
+    thought="Framing the problem purely around emissions was too narrow; adaptation matters equally.",
+    thought_number=6,
+    total_thoughts=6,
+    next_thought_needed=True,
+    stage="Problem Definition",
+    is_revision=True,
+    revises_thought_number=1
+)
+
+# Fork an alternative line of reasoning
+process_thought(
+    thought="What if we approach this from a market-incentive angle instead?",
+    thought_number=7,
+    total_thoughts=7,
+    next_thought_needed=True,
+    stage="Analysis",
+    branch_from_thought=3,
+    branch_id="market-incentives"
 )
 ```
 
@@ -395,8 +424,14 @@ Generates a summary of your entire thinking process.
       {"number": 2, "stage": "Research"},
       {"number": 3, "stage": "Analysis"},
       {"number": 4, "stage": "Synthesis"},
-      {"number": 5, "stage": "Conclusion"}
-    ]
+      {"number": 5, "stage": "Conclusion"},
+      {"number": 6, "stage": "Problem Definition", "isRevision": true},
+      {"number": 7, "stage": "Analysis", "branchId": "market-incentives"}
+    ],
+    "branches": {
+      "market-incentives": {"fromThought": 3, "thoughtCount": 1}
+    },
+    "revisionCount": 1
   }
 }
 ```
@@ -411,21 +446,32 @@ Exports the current thinking session to a JSON file for sharing or backup.
 
 **Parameters:**
 
-- `file_path` (string): Path to the output JSON file (parent directories are created automatically)
+- `file_path` (string): Path to the output JSON file. Since v0.6.0, exports are confined to the `exports/` subdirectory of the storage directory; relative paths resolve to `~/.mcp_sequential_thinking/exports/` and parent directories are created automatically.
 
 **Example:**
 
 ```python
-export_session(file_path="/home/user/exports/my-analysis.json")
+export_session(file_path="my-analysis.json")
+# -> written to ~/.mcp_sequential_thinking/exports/my-analysis.json
 ```
 
 ### 5. `import_session`
 
-Imports a previously exported thinking session from a JSON file.
+Imports a previously exported thinking session from a JSON file. Exports created with v0.5.x remain importable.
 
 **Parameters:**
 
-- `file_path` (string): Path to the JSON file to import
+- `file_path` (string): Path to the JSON file to import. Like exports, resolved inside the `exports/` subdirectory of the storage directory.
+
+## Comparison to the official sequential-thinking server
+
+The [official MCP sequential-thinking server](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) provides the core paradigm: numbered thoughts with revisions and branching, held in memory for the duration of the process. This server implements the same paradigm and adds:
+
+- **Persistence**: sessions survive restarts (append-only JSONL log with crash recovery and automatic migration), and can be exported, shared and re-imported as JSON.
+- **Thinking stages**: thoughts are categorized into cognitive stages (Problem Definition, Research, Analysis, Synthesis, Conclusion), enabling stage-based filtering and completeness checks.
+- **Analysis**: related-thought detection via stages and tags, per-thought progress, and rich summaries including branch and revision statistics.
+
+If you only need ephemeral chain-of-thought scaffolding, the official server is a lighter choice; if you want durable, analyzable thinking sessions, this one is built for that.
 
 ## Practical Applications
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ If you've installed the package globally with `pip install -e .`:
 
 ### Option 4: Using uvx (no local install needed)
 
+As of v0.6.0 the package is published on PyPI as `mcp-sequential-thinking`, so uvx can fetch it directly:
+
+```json
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "command": "uvx",
+      "args": ["mcp-sequential-thinking"]
+    }
+  }
+}
+```
+
+For unreleased versions, install straight from the repository instead:
+
 ```json
 {
   "mcpServers": {

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
+| older   | ❌        |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately by email to **arben.ademi@tuta.io**.
+Do not open a public GitHub issue for security problems.
+
+You can expect an initial response within a few days. Please include a
+description of the issue, steps to reproduce, and the affected version.

--- a/mcp_sequential_thinking/analysis.py
+++ b/mcp_sequential_thinking/analysis.py
@@ -88,7 +88,7 @@ class ThoughtAnalyzer:
             return {"summary": "No thoughts recorded yet"}
 
         # Group thoughts by stage
-        stages = {}
+        stages: Dict[str, List[ThoughtData]] = {}
         for thought in thoughts:
             if thought.stage.value not in stages:
                 stages[thought.stage.value] = []
@@ -114,7 +114,7 @@ class ThoughtAnalyzer:
                 max_total = max((t.total_thoughts for t in thoughts), default=0)
 
             # Calculate percent complete safely
-            percent_complete = 0
+            percent_complete: float = 0.0
             if max_total > 0:
                 percent_complete = (len(thoughts) / max_total) * 100
 

--- a/mcp_sequential_thinking/analysis.py
+++ b/mcp_sequential_thinking/analysis.py
@@ -11,6 +11,16 @@ class ThoughtAnalyzer:
     """Analyzer for thought data to extract insights and patterns."""
 
     @staticmethod
+    def _is_mainline(thought: ThoughtData) -> bool:
+        """Whether a thought belongs to the main line of reasoning.
+
+        Revisions and branch thoughts are excluded from progress metrics:
+        counting them would report e.g. 160% for a 5-thought session with
+        3 revisions.
+        """
+        return not thought.is_revision and thought.branch_id is None
+
+    @staticmethod
     def find_related_thoughts(
         current_thought: ThoughtData, all_thoughts: List[ThoughtData], max_results: int = 3
     ) -> List[ThoughtData]:
@@ -108,18 +118,21 @@ class ThoughtAnalyzer:
 
         # Create summary
         try:
+            # Progress is based on mainline thoughts only; revisions and
+            # branch thoughts don't advance the sequence.
+            mainline_thoughts = [t for t in thoughts if ThoughtAnalyzer._is_mainline(t)]
+
             # Safely calculate max total thoughts to avoid division by zero
-            max_total = 0
-            if thoughts:
-                max_total = max((t.total_thoughts for t in thoughts), default=0)
+            max_total = max((t.total_thoughts for t in mainline_thoughts), default=0)
 
             # Calculate percent complete safely
             percent_complete: float = 0.0
             if max_total > 0:
-                percent_complete = (len(thoughts) / max_total) * 100
+                percent_complete = (len(mainline_thoughts) / max_total) * 100
 
             logger.debug(
-                f"Calculating completion: {len(thoughts)}/{max_total} = {percent_complete}%"
+                f"Calculating completion: {len(mainline_thoughts)}/{max_total} "
+                f"= {percent_complete}%"
             )
 
             # Build the summary dictionary with more readable and
@@ -132,7 +145,26 @@ class ThoughtAnalyzer:
             sorted_thoughts = sorted(thoughts, key=lambda x: x.thought_number)
             timeline_entries = []
             for t in sorted_thoughts:
-                timeline_entries.append({"number": t.thought_number, "stage": t.stage.value})
+                entry: Dict[str, Any] = {"number": t.thought_number, "stage": t.stage.value}
+                if t.is_revision:
+                    entry["isRevision"] = True
+                if t.branch_id is not None:
+                    entry["branchId"] = t.branch_id
+                timeline_entries.append(entry)
+
+            # Aggregate branches: first occurrence defines the fork point.
+            branches: Dict[str, Dict[str, Any]] = {}
+            for t in sorted_thoughts:
+                if t.branch_id is None:
+                    continue
+                if t.branch_id not in branches:
+                    branches[t.branch_id] = {
+                        "fromThought": t.branch_from_thought,
+                        "thoughtCount": 0,
+                    }
+                branches[t.branch_id]["thoughtCount"] += 1
+
+            revision_count = sum(1 for t in thoughts if t.is_revision)
 
             # Create top tags entries
             top_tags_entries = []
@@ -147,6 +179,8 @@ class ThoughtAnalyzer:
                 "totalThoughts": len(thoughts),
                 "stages": stage_counts,
                 "timeline": timeline_entries,
+                "branches": branches,
+                "revisionCount": revision_count,
                 "topTags": top_tags_entries,
                 "completionStatus": {
                     "hasAllStages": all_stages_present,
@@ -179,10 +213,63 @@ class ThoughtAnalyzer:
             t.thought_number >= thought.thought_number for t in same_stage_thoughts
         )
 
-        # Calculate progress
-        progress = (thought.thought_number / thought.total_thoughts) * 100
+        # Calculate progress. Revisions and branch thoughts don't advance the
+        # sequence, so for them progress reflects the mainline position instead
+        # of their own number (which may exceed total_thoughts).
+        if ThoughtAnalyzer._is_mainline(thought):
+            effective_number = thought.thought_number
+        else:
+            effective_number = max(
+                (t.thought_number for t in all_thoughts if ThoughtAnalyzer._is_mainline(t)),
+                default=0,
+            )
+        progress = (effective_number / thought.total_thoughts) * 100
+
+        # For a revision, surface a snippet of the mainline thought it revises.
+        revision_of = None
+        if thought.is_revision and thought.revises_thought_number is not None:
+            revised = next(
+                (
+                    t
+                    for t in all_thoughts
+                    if ThoughtAnalyzer._is_mainline(t)
+                    and t.thought_number == thought.revises_thought_number
+                ),
+                None,
+            )
+            if revised is not None:
+                revision_of = {
+                    "thoughtNumber": revised.thought_number,
+                    "stage": revised.stage.value,
+                    "snippet": (
+                        revised.thought[:100] + "..."
+                        if len(revised.thought) > 100
+                        else revised.thought
+                    ),
+                }
 
         # Create analysis
+        analysis_block: Dict[str, Any] = {
+            "relatedThoughtsCount": len(related_thoughts),
+            "relatedThoughtSummaries": [
+                {
+                    "thoughtNumber": t.thought_number,
+                    "stage": t.stage.value,
+                    "snippet": (
+                        t.thought[:100] + "..." if len(t.thought) > 100 else t.thought
+                    ),
+                }
+                for t in related_thoughts
+            ],
+            "progress": progress,
+            "isFirstInStage": is_first_in_stage,
+            "isRevision": thought.is_revision,
+            "revisedThought": thought.revises_thought_number,
+            "branchId": thought.branch_id,
+        }
+        if revision_of is not None:
+            analysis_block["revisionOf"] = revision_of
+
         return {
             "thoughtAnalysis": {
                 "currentThought": {
@@ -193,21 +280,7 @@ class ThoughtAnalyzer:
                     "tags": thought.tags,
                     "timestamp": thought.timestamp,
                 },
-                "analysis": {
-                    "relatedThoughtsCount": len(related_thoughts),
-                    "relatedThoughtSummaries": [
-                        {
-                            "thoughtNumber": t.thought_number,
-                            "stage": t.stage.value,
-                            "snippet": (
-                                t.thought[:100] + "..." if len(t.thought) > 100 else t.thought
-                            ),
-                        }
-                        for t in related_thoughts
-                    ],
-                    "progress": progress,
-                    "isFirstInStage": is_first_in_stage,
-                },
+                "analysis": analysis_block,
                 "context": {
                     "thoughtHistoryLength": len(all_thoughts),
                     "currentStage": thought.stage.value,

--- a/mcp_sequential_thinking/models.py
+++ b/mcp_sequential_thinking/models.py
@@ -1,8 +1,14 @@
-from typing import List
+import re
+from typing import List, Optional
 from enum import Enum
 from datetime import datetime
 from uuid import uuid4, UUID
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from pydantic import BaseModel, Field, field_validator, model_validator, ValidationInfo
+
+# branch_id ends up in files and tool output, so it is restricted to a short,
+# filesystem- and log-safe alphabet.
+BRANCH_ID_MAX_LENGTH = 64
+BRANCH_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 class ThoughtStage(Enum):
@@ -46,6 +52,10 @@ class ThoughtData(BaseModel):
     tags: List[str] = Field(default_factory=list)
     axioms_used: List[str] = Field(default_factory=list)
     assumptions_challenged: List[str] = Field(default_factory=list)
+    is_revision: bool = False
+    revises_thought_number: Optional[int] = None
+    branch_from_thought: Optional[int] = None
+    branch_id: Optional[str] = None
     timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
     id: UUID = Field(default_factory=uuid4)
 
@@ -84,6 +94,41 @@ class ThoughtData(BaseModel):
             raise ValueError("Total thoughts must be greater or equal to current thought number")
         return v
 
+    @model_validator(mode='after')
+    def validate_revision_and_branch(self) -> 'ThoughtData':
+        """Validate the cross-field rules for revisions and branches."""
+        if self.is_revision and self.revises_thought_number is None:
+            raise ValueError("is_revision=True requires revises_thought_number to be set")
+        if self.revises_thought_number is not None and not self.is_revision:
+            raise ValueError("revises_thought_number requires is_revision=True")
+        if self.is_revision and self.branch_from_thought is not None:
+            raise ValueError(
+                "A thought cannot be a revision and a branch start at the same time"
+            )
+        if self.branch_id is not None and self.branch_from_thought is None:
+            raise ValueError("branch_id requires branch_from_thought to be set")
+
+        for field_name, value in (
+            ("revises_thought_number", self.revises_thought_number),
+            ("branch_from_thought", self.branch_from_thought),
+        ):
+            if value is not None and not 1 <= value < self.thought_number:
+                raise ValueError(
+                    f"{field_name} must be >= 1 and < thought_number "
+                    f"({self.thought_number}), got {value}"
+                )
+
+        if self.branch_id is not None and (
+            len(self.branch_id) > BRANCH_ID_MAX_LENGTH
+            or not BRANCH_ID_PATTERN.match(self.branch_id)
+        ):
+            raise ValueError(
+                f"branch_id must be 1-{BRANCH_ID_MAX_LENGTH} characters from "
+                "[A-Za-z0-9_-]"
+            )
+
+        return self
+
     def to_dict(self, include_id: bool = False) -> dict:
         """Convert the thought data to a dictionary representation.
 
@@ -107,6 +152,17 @@ class ThoughtData(BaseModel):
             "timestamp": self.timestamp,
         }
 
+        # Revision/branch fields are only emitted when set, keeping records
+        # compact and older v2 files readable without them.
+        if self.is_revision:
+            result["isRevision"] = self.is_revision
+        if self.revises_thought_number is not None:
+            result["revisesThoughtNumber"] = self.revises_thought_number
+        if self.branch_from_thought is not None:
+            result["branchFromThought"] = self.branch_from_thought
+        if self.branch_id is not None:
+            result["branchId"] = self.branch_id
+
         if include_id:
             result["id"] = str(self.id)
 
@@ -129,7 +185,11 @@ class ThoughtData(BaseModel):
             "totalThoughts": "total_thoughts",
             "nextThoughtNeeded": "next_thought_needed",
             "axiomsUsed": "axioms_used",
-            "assumptionsChallenged": "assumptions_challenged"
+            "assumptionsChallenged": "assumptions_challenged",
+            "isRevision": "is_revision",
+            "revisesThoughtNumber": "revises_thought_number",
+            "branchFromThought": "branch_from_thought",
+            "branchId": "branch_id"
         }
         
         # Process known direct mappings

--- a/mcp_sequential_thinking/server.py
+++ b/mcp_sequential_thinking/server.py
@@ -37,6 +37,10 @@ async def process_thought(
     tags: Optional[List[str]] = None,
     axioms_used: Optional[List[str]] = None,
     assumptions_challenged: Optional[List[str]] = None,
+    is_revision: bool = False,
+    revises_thought_number: Optional[int] = None,
+    branch_from_thought: Optional[int] = None,
+    branch_id: Optional[str] = None,
     ctx: Optional[Context] = None,
 ) -> dict:
     """Add a sequential thought with its metadata.
@@ -50,6 +54,10 @@ async def process_thought(
         tags: Optional keywords or categories for the thought
         axioms_used: Optional list of principles or axioms used in this thought
         assumptions_challenged: Optional list of assumptions challenged by this thought
+        is_revision: Whether this thought revises an earlier thought
+        revises_thought_number: The number of the earlier thought being revised (required if is_revision is true)
+        branch_from_thought: The thought number this thought branches from, to explore an alternative path
+        branch_id: Identifier for the branch (letters, digits, '-', '_'; max 64 chars; requires branch_from_thought)
         ctx: Optional MCP context object
 
     Returns:
@@ -81,6 +89,10 @@ async def process_thought(
             tags=tags,
             axioms_used=axioms_used,
             assumptions_challenged=assumptions_challenged,
+            is_revision=is_revision,
+            revises_thought_number=revises_thought_number,
+            branch_from_thought=branch_from_thought,
+            branch_id=branch_id,
         )
 
         # Store (validation already happened during ThoughtData construction)

--- a/mcp_sequential_thinking/server.py
+++ b/mcp_sequential_thinking/server.py
@@ -176,7 +176,7 @@ def import_session(file_path: str) -> dict:
         return {"error": str(e), "status": "failed"}
 
 
-def main():
+def main() -> None:
     """Entry point for the MCP server."""
     logger.info("Starting Sequential Thinking MCP server")
 
@@ -198,10 +198,7 @@ def main():
 
 
 if __name__ == "__main__":
-    # When running the script directly, ensure we're in the right directory
-    import os
-    import sys
-
+    # When running the script directly, ensure we're in the right directory.
     # Add the parent directory to sys.path if needed
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if parent_dir not in sys.path:

--- a/mcp_sequential_thinking/storage.py
+++ b/mcp_sequential_thinking/storage.py
@@ -33,6 +33,11 @@ class ThoughtStorage:
         self.current_session_file = self.storage_dir / "current_session.json"
         self.lock_file = self.storage_dir / "current_session.lock"
 
+        # Exports/imports are confined to a dedicated subdirectory so an export
+        # can never clobber the session file (or its lock file). Created lazily
+        # by export_session.
+        self.export_dir = self.storage_dir / "exports"
+
         # Thread safety
         self._lock = threading.RLock()
         self.thought_history: List[ThoughtData] = []
@@ -68,9 +73,12 @@ class ThoughtStorage:
         try:
             resolved.relative_to(base_r)
         except ValueError:
+            # Log the full resolved base server-side, but keep it out of the
+            # client-facing message (it would leak the user's home directory).
+            logger.error(f"Rejected path '{candidate}': resolves outside '{base_r}'")
             raise ValueError(
-                f"Path '{candidate}' is outside the allowed storage directory "
-                f"'{base_r}'. Export/import are confined to the storage directory."
+                f"Path '{candidate}' resolves outside the allowed export directory. "
+                "Export/import paths must stay within the storage area."
             )
         return resolved
 
@@ -139,14 +147,17 @@ class ThoughtStorage:
         """Export the current session to a file.
 
         Args:
-            file_path: Path to save the exported session. Must resolve to a
-                location inside the storage directory.
+            file_path: Path to save the exported session. Relative paths are
+                resolved against the ``exports/`` subdirectory of the storage
+                directory; the result must stay inside it.
 
         Raises:
-            ValueError: If file_path resolves outside the storage directory.
+            ValueError: If file_path resolves outside the export directory.
         """
-        # Confine the caller-controlled path to storage_dir before any file I/O.
-        file_path_obj = self._ensure_within(self.storage_dir, file_path)
+        # Confine the caller-controlled path to export_dir before any file I/O,
+        # so an export can never overwrite the session or lock file.
+        file_path_obj = self._ensure_within(self.export_dir, file_path)
+        self.export_dir.mkdir(parents=True, exist_ok=True)
 
         with self._lock:
             # Use utility function to prepare thoughts for serialization
@@ -173,19 +184,27 @@ class ThoughtStorage:
         """Import a session from a file.
 
         Args:
-            file_path: Path to the file to import
+            file_path: Path to the file to import. Relative paths are resolved
+                against the ``exports/`` subdirectory of the storage directory;
+                the result must stay inside it.
 
         Raises:
-            ValueError: If file_path resolves outside the storage directory,
+            ValueError: If file_path resolves outside the export directory,
                 if the file is not valid JSON, or if it contains semantically
                 invalid thought data. In all error cases the input file and the
                 current session are left untouched.
             FileNotFoundError: If the file doesn't exist.
-            KeyError: If the file doesn't contain valid thought data.
+            KeyError: If the file doesn't contain a 'thoughts' key.
         """
-        # Confine the caller-controlled path to storage_dir before any file I/O.
-        file_path_obj = self._ensure_within(self.storage_dir, file_path)
+        # Confine the caller-controlled path to export_dir before any file I/O.
+        file_path_obj = self._ensure_within(self.export_dir, file_path)
         lock_file = file_path_obj.with_suffix('.lock')
+
+        # load_thoughts_from_file returns [] for missing files (recovery
+        # behaviour for the server's own session file). For an import that
+        # would silently wipe the current session, so reject explicitly.
+        if not file_path_obj.exists():
+            raise FileNotFoundError(f"Import file not found: {file_path}")
 
         # Use utility function to load thoughts. backup_on_corruption defaults to
         # False, so a malformed/invalid input file raises instead of renaming the

--- a/mcp_sequential_thinking/storage.py
+++ b/mcp_sequential_thinking/storage.py
@@ -5,7 +5,14 @@ from datetime import datetime
 
 from .models import ThoughtData, ThoughtStage
 from .logging_conf import configure_logging
-from .storage_utils import prepare_thoughts_for_serialization, save_thoughts_to_file, load_thoughts_from_file
+from .storage_utils import (
+    append_thought_to_jsonl,
+    load_thoughts_from_file,
+    load_thoughts_from_jsonl,
+    prepare_thoughts_for_serialization,
+    rewrite_jsonl,
+    save_thoughts_to_file,
+)
 
 logger = configure_logging("sequential-thinking.storage")
 
@@ -29,8 +36,10 @@ class ThoughtStorage:
         # Create storage directory if it doesn't exist
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
-        # Default session file
-        self.current_session_file = self.storage_dir / "current_session.json"
+        # Default session file (schema v2, append-only JSONL). The legacy v1
+        # JSON file is only read once for migration.
+        self.current_session_file = self.storage_dir / "current_session.jsonl"
+        self.legacy_session_file = self.storage_dir / "current_session.json"
         self.lock_file = self.storage_dir / "current_session.lock"
 
         # Exports/imports are confined to a dedicated subdirectory so an export
@@ -83,37 +92,61 @@ class ThoughtStorage:
         return resolved
 
     def _load_session(self) -> None:
-        """Load thought history from the current session file if it exists."""
+        """Load thought history from the current session file if it exists.
+
+        If no v2 JSONL session exists but a legacy v1 JSON session does, the
+        v1 file is migrated to JSONL once (lossless, idempotent).
+        """
         with self._lock:
-            # Use the utility function to handle loading with proper error handling.
-            # backup_on_corruption=True: this is our own session file, so a corrupt
-            # or invalid file is backed up and we recover with an empty session
-            # rather than crashing the server on startup.
-            self.thought_history = load_thoughts_from_file(
+            if not self.current_session_file.exists() and self.legacy_session_file.exists():
+                self._migrate_v1_session()
+                return
+
+            # backup_on_corruption=True: this is our own session file, so a
+            # corrupt or invalid file is backed up (or a truncated final line
+            # dropped) and we recover rather than crashing the server on startup.
+            self.thought_history = load_thoughts_from_jsonl(
                 self.current_session_file, self.lock_file, backup_on_corruption=True
             )
 
-    def _save_session(self) -> None:
-        """Save the current thought history to the session file."""
-        # Use thread lock to ensure consistent data. Snapshot AND file write
-        # must both run under the lock so a stale snapshot can never be written
-        # after a newer one (RLock makes reentrancy harmless).
-        with self._lock:
-            # Use utility functions to prepare and save thoughts
-            thoughts_with_ids = prepare_thoughts_for_serialization(self.thought_history)
+    def _migrate_v1_session(self) -> None:
+        """Migrate a legacy v1 JSON session file to the v2 JSONL format.
 
-            # Save to file with proper locking
-            save_thoughts_to_file(self.current_session_file, thoughts_with_ids, self.lock_file)
+        The v1 file is loaded (with the usual corruption recovery), rewritten
+        as JSONL, and then renamed to ``current_session.json.migrated-to-v2``
+        so a second start only finds the JSONL file.
+        """
+        thoughts = load_thoughts_from_file(
+            self.legacy_session_file, self.lock_file, backup_on_corruption=True
+        )
+        rewrite_jsonl(
+            self.current_session_file,
+            self.lock_file,
+            prepare_thoughts_for_serialization(thoughts),
+        )
+        # On corruption the v1 file was already renamed to a .bak backup.
+        if self.legacy_session_file.exists():
+            migrated = self.legacy_session_file.with_name("current_session.json.migrated-to-v2")
+            self.legacy_session_file.rename(migrated)
+            logger.info(
+                f"Migrated v1 session ({len(thoughts)} thoughts) to "
+                f"{self.current_session_file}; original kept at {migrated}"
+            )
+        self.thought_history = thoughts
 
     def add_thought(self, thought: ThoughtData) -> None:
-        """Add a thought to the history and save the session.
+        """Add a thought to the history and append it to the session file.
 
         Args:
             thought: The thought data to add
         """
+        # Memory update AND file append run under the lock so disk order
+        # always matches memory order (RLock makes reentrancy harmless).
         with self._lock:
             self.thought_history.append(thought)
-        self._save_session()
+            append_thought_to_jsonl(
+                self.current_session_file, self.lock_file, thought.to_dict(include_id=True)
+            )
 
     def get_all_thoughts(self) -> List[ThoughtData]:
         """Get all thoughts in the current session.
@@ -138,10 +171,10 @@ class ThoughtStorage:
             return [t for t in self.thought_history if t.stage == stage]
 
     def clear_history(self) -> None:
-        """Clear the thought history and save the empty session."""
+        """Clear the thought history and rewrite the session file."""
         with self._lock:
             self.thought_history.clear()
-        self._save_session()
+            rewrite_jsonl(self.current_session_file, self.lock_file, [])
 
     def export_session(self, file_path: str) -> None:
         """Export the current session to a file.
@@ -213,5 +246,8 @@ class ThoughtStorage:
 
         with self._lock:
             self.thought_history = thoughts
-
-        self._save_session()
+            rewrite_jsonl(
+                self.current_session_file,
+                self.lock_file,
+                prepare_thoughts_for_serialization(thoughts),
+            )

--- a/mcp_sequential_thinking/storage_utils.py
+++ b/mcp_sequential_thinking/storage_utils.py
@@ -106,11 +106,16 @@ def load_thoughts_from_file(
         with portalocker.Lock(lock_file, timeout=10) as _, open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
 
+        # A valid session/export file must carry a "thoughts" key. Without this
+        # check, importing an arbitrary JSON file would silently load an empty
+        # list and wipe the current session.
+        if "thoughts" not in data:
+            raise KeyError(
+                f"File {file_path} does not contain a 'thoughts' key and is not a valid session file."
+            )
+
         # Convert data to ThoughtData objects after file is closed
-        thoughts = [
-            ThoughtData.from_dict(thought_dict)
-            for thought_dict in data.get("thoughts", [])
-        ]
+        thoughts = [ThoughtData.from_dict(thought_dict) for thought_dict in data["thoughts"]]
 
         logger.debug(f"Loaded {len(thoughts)} thoughts from {file_path}")
         return thoughts

--- a/mcp_sequential_thinking/storage_utils.py
+++ b/mcp_sequential_thinking/storage_utils.py
@@ -11,6 +11,11 @@ from .logging_conf import configure_logging
 
 logger = configure_logging("sequential-thinking.storage-utils")
 
+# Version of the on-disk session/export schema. Version 2 introduces the
+# append-only JSONL session format (header record + one thought per line)
+# and the top-level "version" field in JSON exports.
+SCHEMA_VERSION = 2
+
 
 def prepare_thoughts_for_serialization(thoughts: List[ThoughtData]) -> List[Dict[str, Any]]:
     """Prepare thoughts for serialization with IDs included.
@@ -39,32 +44,203 @@ def save_thoughts_to_file(
         metadata: Optional additional metadata to include
     """
     data = {
+        "version": SCHEMA_VERSION,
         "thoughts": thoughts,
         "lastUpdated": datetime.now().isoformat()
     }
-    
+
     # Add any additional metadata if provided
     if metadata:
         data.update(metadata)
-    
+
     # Ensure destination directories exist before acquiring the lock.
     file_path.parent.mkdir(parents=True, exist_ok=True)
     lock_file.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write atomically: dump to a temp file in the same directory, fsync, then
-    # os.replace() onto the target. This guarantees the destination is always
-    # either the old or the new complete state, never a truncated half-write.
-    tmp_path = file_path.with_suffix(file_path.suffix + '.tmp')
-
     # Use file locking to ensure thread safety when writing
     with portalocker.Lock(lock_file, timeout=10) as _:
-        with open(tmp_path, 'w', encoding='utf-8') as f:
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, file_path)
+        _atomic_write_text(file_path, json.dumps(data, indent=2, ensure_ascii=False))
 
     logger.debug(f"Saved {len(thoughts)} thoughts to {file_path}")
+
+
+def _atomic_write_text(file_path: Path, text: str) -> None:
+    """Write ``text`` to ``file_path`` atomically.
+
+    Writes to a temp file in the same directory, fsyncs, then ``os.replace()``s
+    onto the target. This guarantees the destination is always either the old
+    or the new complete state, never a truncated half-write. Callers are
+    responsible for holding the appropriate file lock.
+
+    Args:
+        file_path: Destination path.
+        text: Full file content to write.
+    """
+    tmp_path = file_path.with_suffix(file_path.suffix + '.tmp')
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        f.write(text)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, file_path)
+
+
+def _header_record() -> Dict[str, Any]:
+    """Build the header record that starts every JSONL session file."""
+    return {"type": "header", "version": SCHEMA_VERSION, "createdAt": datetime.now().isoformat()}
+
+
+def _dump_record(record: Dict[str, Any]) -> str:
+    """Serialize a single JSONL record (compact, UTF-8-friendly)."""
+    return json.dumps(record, ensure_ascii=False)
+
+
+def append_thought_to_jsonl(
+    file_path: Path,
+    lock_file: Path,
+    thought_dict: Dict[str, Any],
+) -> None:
+    """Append a single thought record to a JSONL session file.
+
+    O(1) per call: the file is opened in append mode, the record is flushed
+    and fsynced. If the file does not exist yet, a header record (schema
+    version 2) is written first.
+
+    Args:
+        file_path: Path to the JSONL session file.
+        lock_file: Path to the lock file.
+        thought_dict: Serialized thought (as from ``ThoughtData.to_dict``).
+    """
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with portalocker.Lock(lock_file, timeout=10) as _:
+        is_new_file = not file_path.exists()
+        with open(file_path, 'a', encoding='utf-8') as f:
+            if is_new_file:
+                f.write(_dump_record(_header_record()) + "\n")
+            f.write(_dump_record({"type": "thought", **thought_dict}) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+    logger.debug(f"Appended thought to {file_path}")
+
+
+def rewrite_jsonl(
+    file_path: Path,
+    lock_file: Path,
+    thoughts: List[Dict[str, Any]],
+) -> None:
+    """Atomically rewrite a JSONL session file with the given thoughts.
+
+    Used by ``clear_history`` and ``import_session``, where the whole session
+    is replaced. The write is atomic (tmp file + fsync + ``os.replace``).
+
+    Args:
+        file_path: Path to the JSONL session file.
+        lock_file: Path to the lock file.
+        thoughts: Serialized thoughts (as from ``ThoughtData.to_dict``).
+    """
+    lines = [_dump_record(_header_record())]
+    lines.extend(_dump_record({"type": "thought", **t}) for t in thoughts)
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with portalocker.Lock(lock_file, timeout=10) as _:
+        _atomic_write_text(file_path, "\n".join(lines) + "\n")
+
+    logger.debug(f"Rewrote {len(thoughts)} thoughts to {file_path}")
+
+
+def load_thoughts_from_jsonl(
+    file_path: Path,
+    lock_file: Path,
+    backup_on_corruption: bool = False,
+) -> List[ThoughtData]:
+    """Load thoughts from a JSONL session file (schema version 2).
+
+    Args:
+        file_path: Path to the JSONL session file.
+        lock_file: Path to the lock file.
+        backup_on_corruption: Recovery behaviour reserved for the server's own
+            session file. When True, a corrupt final line (interrupted append)
+            is dropped with a warning and the valid prefix is kept; any other
+            corruption renames the file to a ``.bak.<timestamp>`` backup and
+            returns an empty list. When False, all errors propagate.
+
+    Returns:
+        List[ThoughtData]: Loaded thought data objects.
+
+    Raises:
+        ValueError: If the file is not a valid version-2 JSONL session file
+            (only when ``backup_on_corruption`` is False). This includes
+            ``json.JSONDecodeError`` and pydantic validation errors, which are
+            ``ValueError`` subclasses.
+    """
+    if not file_path.exists():
+        return []
+
+    try:
+        with portalocker.Lock(lock_file, timeout=10) as _, open(file_path, 'r', encoding='utf-8') as f:
+            raw_lines = f.read().splitlines()
+
+        # Ignore trailing blank lines.
+        while raw_lines and not raw_lines[-1].strip():
+            raw_lines.pop()
+
+        if not raw_lines:
+            return []
+
+        header = json.loads(raw_lines[0])
+        if not isinstance(header, dict) or header.get("type") != "header":
+            raise ValueError(
+                f"File {file_path} does not start with a header record and is not a "
+                "valid session file."
+            )
+        version = header.get("version")
+        if version != SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported session schema version {version!r} in {file_path}; this "
+                f"server supports version {SCHEMA_VERSION}. The file may have been "
+                "created by a newer release."
+            )
+
+        thoughts: List[ThoughtData] = []
+        last_index = len(raw_lines) - 1
+        for index, line in enumerate(raw_lines[1:], start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                if backup_on_corruption and index == last_index:
+                    # An interrupted append leaves exactly one truncated final
+                    # line; the prefix is still a consistent session.
+                    logger.warning(
+                        f"Dropping truncated final record in {file_path} (interrupted write)"
+                    )
+                    break
+                raise
+            if not isinstance(record, dict) or record.get("type") != "thought":
+                raise ValueError(
+                    f"Unexpected record on line {index + 1} of {file_path}: "
+                    "expected a thought record."
+                )
+            thoughts.append(ThoughtData.from_dict(record))
+
+        logger.debug(f"Loaded {len(thoughts)} thoughts from {file_path}")
+        return thoughts
+
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
+        logger.error(f"Error loading from {file_path}: {e}")
+
+        if not backup_on_corruption:
+            raise
+
+        backup_file = file_path.with_suffix(f".bak.{datetime.now().strftime('%Y%m%d%H%M%S')}")
+        file_path.rename(backup_file)
+        logger.info(f"Created backup of corrupted file at {backup_file}")
+        return []
 
 
 def load_thoughts_from_file(
@@ -105,6 +281,15 @@ def load_thoughts_from_file(
         # for cleaner resource management
         with portalocker.Lock(lock_file, timeout=10) as _, open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
+
+        # Legacy (v0.5.x) exports have no "version" field and count as v1.
+        version = data.get("version", 1)
+        if version not in (1, SCHEMA_VERSION):
+            raise ValueError(
+                f"Unsupported export schema version {version!r} in {file_path}; this "
+                f"server supports versions 1 and {SCHEMA_VERSION}. The file may have "
+                "been created by a newer release."
+            )
 
         # A valid session/export file must carry a "thoughts" key. Without this
         # check, importing an arbitrary JSON file would silently load an empty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "sequential-thinking"
-version = "0.5.0"
+name = "mcp-sequential-thinking"
+version = "0.6.0"
 description = "A Sequential Thinking MCP Server for advanced problem solving"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -38,7 +38,7 @@ web = [
 ]
 
 all = [
-    "sequential-thinking[dev,vis,web]",
+    "mcp-sequential-thinking[dev,vis,web]",
 ]
 
 [project.urls]

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -95,6 +95,112 @@ class TestThoughtAnalyzer(unittest.TestCase):
         self.assertTrue("topTags" in summary["summary"])
         self.assertTrue("completionStatus" in summary["summary"])
 
+    def test_progress_ignores_revisions_and_branches(self):
+        """Revisions and branch thoughts don't advance progress metrics."""
+        revision = ThoughtData(
+            thought="Revising the problem definition",
+            thought_number=5,
+            total_thoughts=5,
+            next_thought_needed=True,
+            stage=ThoughtStage.PROBLEM_DEFINITION,
+            is_revision=True,
+            revises_thought_number=1,
+        )
+        branch = ThoughtData(
+            thought="Branching into an alternative",
+            thought_number=6,
+            total_thoughts=6,
+            next_thought_needed=True,
+            stage=ThoughtStage.ANALYSIS,
+            branch_from_thought=3,
+            branch_id="alt",
+        )
+        all_thoughts = self.all_thoughts + [revision, branch]
+
+        # Summary: 4 mainline thoughts of max_total 5 => 80%, not 120%.
+        summary = ThoughtAnalyzer.generate_summary(all_thoughts)
+        self.assertEqual(summary["summary"]["completionStatus"]["percentComplete"], 80.0)
+
+        # analyze_thought for the revision uses the mainline position (4/5),
+        # not its own number (5/5).
+        analysis = ThoughtAnalyzer.analyze_thought(revision, all_thoughts)
+        self.assertEqual(analysis["thoughtAnalysis"]["analysis"]["progress"], 80.0)
+
+    def test_summary_counts_branches_and_revisions(self):
+        """Summary reports a branches object and a revision count."""
+        revision = ThoughtData(
+            thought="Revision of thought 2",
+            thought_number=5,
+            total_thoughts=5,
+            next_thought_needed=True,
+            stage=ThoughtStage.RESEARCH,
+            is_revision=True,
+            revises_thought_number=2,
+        )
+        branch_a = ThoughtData(
+            thought="First thought on branch alt",
+            thought_number=6,
+            total_thoughts=6,
+            next_thought_needed=True,
+            stage=ThoughtStage.ANALYSIS,
+            branch_from_thought=3,
+            branch_id="alt",
+        )
+        branch_b = ThoughtData(
+            thought="Second thought on branch alt",
+            thought_number=7,
+            total_thoughts=7,
+            next_thought_needed=False,
+            stage=ThoughtStage.SYNTHESIS,
+            branch_from_thought=3,
+            branch_id="alt",
+        )
+        all_thoughts = self.all_thoughts + [revision, branch_a, branch_b]
+
+        summary = ThoughtAnalyzer.generate_summary(all_thoughts)["summary"]
+
+        self.assertEqual(summary["revisionCount"], 1)
+        self.assertEqual(summary["branches"], {"alt": {"fromThought": 3, "thoughtCount": 2}})
+
+        # Timeline entries flag revisions and branches.
+        by_number = {e["number"]: e for e in summary["timeline"]}
+        self.assertTrue(by_number[5]["isRevision"])
+        self.assertEqual(by_number[6]["branchId"], "alt")
+        self.assertNotIn("isRevision", by_number[1])
+        self.assertNotIn("branchId", by_number[1])
+
+    def test_analyze_revision_includes_revision_of(self):
+        """Analyzing a revision surfaces a snippet of the revised thought."""
+        revision = ThoughtData(
+            thought="Better framing of the problem",
+            thought_number=5,
+            total_thoughts=5,
+            next_thought_needed=True,
+            stage=ThoughtStage.PROBLEM_DEFINITION,
+            is_revision=True,
+            revises_thought_number=1,
+        )
+        all_thoughts = self.all_thoughts + [revision]
+
+        analysis = ThoughtAnalyzer.analyze_thought(revision, all_thoughts)
+        block = analysis["thoughtAnalysis"]["analysis"]
+
+        self.assertTrue(block["isRevision"])
+        self.assertEqual(block["revisedThought"], 1)
+        self.assertIsNone(block["branchId"])
+        self.assertEqual(block["revisionOf"]["thoughtNumber"], 1)
+        self.assertIn("First thought about climate change", block["revisionOf"]["snippet"])
+
+    def test_analyze_mainline_thought_reports_revision_fields(self):
+        """Mainline thoughts report the revision fields with null/false values."""
+        analysis = ThoughtAnalyzer.analyze_thought(self.thought1, self.all_thoughts)
+        block = analysis["thoughtAnalysis"]["analysis"]
+
+        self.assertFalse(block["isRevision"])
+        self.assertIsNone(block["revisedThought"])
+        self.assertIsNone(block["branchId"])
+        self.assertNotIn("revisionOf", block)
+
     def test_analyze_thought(self):
         """Test analyzing a thought."""
         analysis = ThoughtAnalyzer.analyze_thought(self.thought1, self.all_thoughts)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,6 +108,131 @@ class TestThoughtData(unittest.TestCase):
 
         self.assertEqual(thought.to_dict(), expected_dict)
 
+    def _base_kwargs(self, **overrides):
+        kwargs = {
+            "thought": "Test thought",
+            "thought_number": 3,
+            "total_thoughts": 5,
+            "next_thought_needed": True,
+            "stage": ThoughtStage.ANALYSIS,
+        }
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_revision_valid(self):
+        """A revision with a valid earlier thought number is accepted."""
+        thought = ThoughtData(**self._base_kwargs(is_revision=True, revises_thought_number=1))
+        self.assertTrue(thought.is_revision)
+        self.assertEqual(thought.revises_thought_number, 1)
+
+    def test_revision_without_number_rejected(self):
+        """is_revision=True without revises_thought_number is rejected."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(is_revision=True))
+
+    def test_revises_number_without_flag_rejected(self):
+        """revises_thought_number without is_revision=True is rejected."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(revises_thought_number=1))
+
+    def test_revises_number_must_be_earlier(self):
+        """revises_thought_number must be >= 1 and < thought_number."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(is_revision=True, revises_thought_number=3))
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(is_revision=True, revises_thought_number=0))
+
+    def test_branch_valid(self):
+        """A branch with a valid fork point and id is accepted."""
+        thought = ThoughtData(
+            **self._base_kwargs(branch_from_thought=2, branch_id="alt-path_1")
+        )
+        self.assertEqual(thought.branch_from_thought, 2)
+        self.assertEqual(thought.branch_id, "alt-path_1")
+
+    def test_branch_from_must_be_earlier(self):
+        """branch_from_thought must be >= 1 and < thought_number."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(branch_from_thought=3, branch_id="alt"))
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(branch_from_thought=0, branch_id="alt"))
+
+    def test_branch_id_requires_branch_from(self):
+        """branch_id without branch_from_thought is rejected."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(branch_id="alt"))
+
+    def test_branch_id_invalid_characters_rejected(self):
+        """branch_id outside [A-Za-z0-9_-] or longer than 64 chars is rejected."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(branch_from_thought=1, branch_id="bad id!"))
+        with self.assertRaises(ValidationError):
+            ThoughtData(**self._base_kwargs(branch_from_thought=1, branch_id="x" * 65))
+
+    def test_revision_and_branch_mutually_exclusive(self):
+        """A thought cannot be a revision and a branch start at the same time."""
+        from pydantic import ValidationError
+
+        with self.assertRaises(ValidationError):
+            ThoughtData(
+                **self._base_kwargs(
+                    is_revision=True,
+                    revises_thought_number=1,
+                    branch_from_thought=2,
+                    branch_id="alt",
+                )
+            )
+
+    def test_to_dict_omits_default_revision_fields(self):
+        """Revision/branch fields are omitted from to_dict when at defaults."""
+        thought = ThoughtData(**self._base_kwargs())
+        d = thought.to_dict()
+        for key in ("isRevision", "revisesThoughtNumber", "branchFromThought", "branchId"):
+            self.assertNotIn(key, d)
+
+    def test_revision_branch_dict_roundtrip(self):
+        """to_dict/from_dict preserve revision and branch fields."""
+        revision = ThoughtData(**self._base_kwargs(is_revision=True, revises_thought_number=2))
+        d = revision.to_dict()
+        self.assertTrue(d["isRevision"])
+        self.assertEqual(d["revisesThoughtNumber"], 2)
+        restored = ThoughtData.from_dict(d)
+        self.assertTrue(restored.is_revision)
+        self.assertEqual(restored.revises_thought_number, 2)
+
+        branch = ThoughtData(**self._base_kwargs(branch_from_thought=1, branch_id="alt"))
+        restored_branch = ThoughtData.from_dict(branch.to_dict())
+        self.assertEqual(restored_branch.branch_from_thought, 1)
+        self.assertEqual(restored_branch.branch_id, "alt")
+
+    def test_from_dict_defaults_missing_revision_fields(self):
+        """Records without revision/branch fields (pre-revision v2 files) load
+        with defaults."""
+        data = {
+            "thought": "Old record",
+            "thoughtNumber": 1,
+            "totalThoughts": 1,
+            "nextThoughtNeeded": False,
+            "stage": "Conclusion",
+        }
+        thought = ThoughtData.from_dict(data)
+        self.assertFalse(thought.is_revision)
+        self.assertIsNone(thought.revises_thought_number)
+        self.assertIsNone(thought.branch_from_thought)
+        self.assertIsNone(thought.branch_id)
+
     def test_from_dict(self):
         """Test creation from dictionary."""
         data = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -57,6 +57,53 @@ class TestProcessThought(unittest.TestCase):
         self.assertIsInstance(result, dict)
         self.assertIn("thoughtAnalysis", result)
 
+    def test_process_thought_revision_returns_revision_of(self):
+        """A revision thought reports revisionOf with a snippet of the
+        revised mainline thought."""
+        asyncio.run(
+            self.server.process_thought(
+                thought="Original take on the problem",
+                thought_number=1,
+                total_thoughts=3,
+                next_thought_needed=True,
+                stage="Problem Definition",
+            )
+        )
+
+        result = asyncio.run(
+            self.server.process_thought(
+                thought="Sharper framing of the problem",
+                thought_number=2,
+                total_thoughts=3,
+                next_thought_needed=True,
+                stage="Problem Definition",
+                is_revision=True,
+                revises_thought_number=1,
+            )
+        )
+
+        block = result["thoughtAnalysis"]["analysis"]
+        self.assertTrue(block["isRevision"])
+        self.assertEqual(block["revisedThought"], 1)
+        self.assertEqual(block["revisionOf"]["thoughtNumber"], 1)
+        self.assertIn("Original take", block["revisionOf"]["snippet"])
+
+    def test_process_thought_invalid_revision_params_fail_gracefully(self):
+        """Validation errors surface as {'status': 'failed'} instead of raising."""
+        result = asyncio.run(
+            self.server.process_thought(
+                thought="Bad revision",
+                thought_number=1,
+                total_thoughts=1,
+                next_thought_needed=False,
+                stage="Conclusion",
+                is_revision=True,  # missing revises_thought_number
+            )
+        )
+
+        self.assertEqual(result.get("status"), "failed")
+        self.assertIn("error", result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -542,6 +542,40 @@ class TestThoughtStorage(unittest.TestCase):
         self.assertEqual(storage.thought_history, [])
         self.assertEqual(len(list(Path(self.temp_dir.name).glob("current_session.bak.*"))), 1)
 
+    def test_jsonl_roundtrip_with_revision_and_branch_fields(self):
+        """Revision/branch fields survive the JSONL roundtrip."""
+        mainline = self._make_thought(1)
+        revision = ThoughtData(
+            thought="Revised first thought",
+            thought_number=2,
+            total_thoughts=3,
+            next_thought_needed=True,
+            stage=ThoughtStage.ANALYSIS,
+            is_revision=True,
+            revises_thought_number=1,
+        )
+        branch = ThoughtData(
+            thought="Alternative path",
+            thought_number=3,
+            total_thoughts=3,
+            next_thought_needed=False,
+            stage=ThoughtStage.SYNTHESIS,
+            branch_from_thought=1,
+            branch_id="alt-1",
+        )
+        for t in (mainline, revision, branch):
+            self.storage.add_thought(t)
+
+        reloaded = ThoughtStorage(self.temp_dir.name).get_all_thoughts()
+
+        self.assertEqual(len(reloaded), 3)
+        self.assertTrue(reloaded[1].is_revision)
+        self.assertEqual(reloaded[1].revises_thought_number, 1)
+        self.assertEqual(reloaded[2].branch_from_thought, 1)
+        self.assertEqual(reloaded[2].branch_id, "alt-1")
+        self.assertFalse(reloaded[0].is_revision)
+        self.assertIsNone(reloaded[0].branch_id)
+
     def test_import_v1_export_still_works(self):
         """A v0.5.0 JSON export (no 'version' field) is still importable."""
         export_dir = Path(self.temp_dir.name) / "exports"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -147,11 +147,10 @@ class TestThoughtStorage(unittest.TestCase):
         )
         self.storage.add_thought(thought)
 
-        nested_dir = Path(self.temp_dir.name) / "exports" / "nested"
-        export_file = nested_dir / "export.json"
+        # Relative paths resolve inside the exports/ subdirectory.
+        self.storage.export_session("nested/export.json")
 
-        self.storage.export_session(str(export_file))
-
+        export_file = Path(self.temp_dir.name) / "exports" / "nested" / "export.json"
         self.assertTrue(export_file.exists())
 
     def test_export_import_session(self):
@@ -175,9 +174,10 @@ class TestThoughtStorage(unittest.TestCase):
         self.storage.add_thought(thought1)
         self.storage.add_thought(thought2)
         
-        # Export the session
-        export_file = os.path.join(self.temp_dir.name, "export.json")
+        # Export the session (relative path lands in the exports/ subdirectory)
+        export_file = "export.json"
         self.storage.export_session(export_file)
+        self.assertTrue((Path(self.temp_dir.name) / "exports" / "export.json").exists())
         
         # Clear the history
         self.storage.clear_history()
@@ -247,8 +247,10 @@ class TestThoughtStorage(unittest.TestCase):
         self.storage.add_thought(thought)
         self.assertEqual(len(self.storage.thought_history), 1)
 
-        # A plain text file inside the storage dir (passes containment, fails parse).
-        notes = Path(self.temp_dir.name) / "notes.txt"
+        # A plain text file inside the export dir (passes containment, fails parse).
+        export_dir = Path(self.temp_dir.name) / "exports"
+        export_dir.mkdir()
+        notes = export_dir / "notes.txt"
         notes.write_text("just some notes, not json", encoding="utf-8")
 
         with self.assertRaises(ValueError):
@@ -257,7 +259,7 @@ class TestThoughtStorage(unittest.TestCase):
         # Input file unchanged, not renamed.
         self.assertTrue(notes.exists())
         self.assertEqual(notes.read_text(encoding="utf-8"), "just some notes, not json")
-        self.assertEqual(list(Path(self.temp_dir.name).glob("notes.bak.*")), [])
+        self.assertEqual(list(export_dir.glob("notes.bak.*")), [])
 
         # Current session unchanged in memory and on disk.
         self.assertEqual(len(self.storage.thought_history), 1)
@@ -329,6 +331,67 @@ class TestThoughtStorage(unittest.TestCase):
             traversal = os.path.join(self.temp_dir.name, "..", "escape.json")
             with self.assertRaises(ValueError):
                 self.storage.import_session(traversal)
+
+    def test_export_cannot_overwrite_session_file(self):
+        """An export path traversing out of exports/ onto the session file is
+        rejected and the session file is left untouched."""
+        thought = ThoughtData(
+            thought="Test thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.CONCLUSION,
+        )
+        self.storage.add_thought(thought)
+
+        session_file = Path(self.temp_dir.name) / "current_session.json"
+        before = session_file.read_text(encoding="utf-8")
+
+        with self.assertRaises(ValueError):
+            self.storage.export_session("../current_session.json")
+
+        self.assertEqual(session_file.read_text(encoding="utf-8"), before)
+
+    def test_import_rejects_file_without_thoughts_key(self):
+        """Importing valid JSON without a 'thoughts' key raises and leaves the
+        current session and the source file untouched."""
+        thought = ThoughtData(
+            thought="Existing thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.PROBLEM_DEFINITION,
+        )
+        self.storage.add_thought(thought)
+
+        export_dir = Path(self.temp_dir.name) / "exports"
+        export_dir.mkdir()
+        wrong_file = export_dir / "wrong.json"
+        wrong_file.write_text(json.dumps({"foo": 1}), encoding="utf-8")
+
+        with self.assertRaises((KeyError, ValueError)):
+            self.storage.import_session(str(wrong_file))
+
+        # Session unchanged, source file unchanged.
+        self.assertEqual(len(self.storage.thought_history), 1)
+        self.assertEqual(wrong_file.read_text(encoding="utf-8"), json.dumps({"foo": 1}))
+
+    def test_import_missing_file_raises_and_preserves_state(self):
+        """Importing a nonexistent file raises instead of silently wiping the
+        current session."""
+        thought = ThoughtData(
+            thought="Existing thought",
+            thought_number=1,
+            total_thoughts=1,
+            next_thought_needed=False,
+            stage=ThoughtStage.PROBLEM_DEFINITION,
+        )
+        self.storage.add_thought(thought)
+
+        with self.assertRaises(FileNotFoundError):
+            self.storage.import_session("does-not-exist.json")
+
+        self.assertEqual(len(self.storage.thought_history), 1)
 
     # ------------------------------------------------------------------
     # T7: atomic write leaves no temp file behind

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -9,6 +9,15 @@ from mcp_sequential_thinking.models import ThoughtStage, ThoughtData
 from mcp_sequential_thinking.storage import ThoughtStorage
 
 
+def read_jsonl_records(session_file):
+    """Parse a JSONL session file into (header, thought_records)."""
+    lines = session_file.read_text(encoding="utf-8").splitlines()
+    records = [json.loads(line) for line in lines if line.strip()]
+    header = records[0]
+    thoughts = [r for r in records[1:] if r.get("type") == "thought"]
+    return header, thoughts
+
+
 class TestThoughtStorage(unittest.TestCase):
     """Test cases for the ThoughtStorage class."""
     
@@ -38,14 +47,15 @@ class TestThoughtStorage(unittest.TestCase):
         self.assertEqual(self.storage.thought_history[0], thought)
         
         # Check that the session file was created
-        session_file = Path(self.temp_dir.name) / "current_session.json"
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
         self.assertTrue(session_file.exists())
-        
+
         # Check the content of the session file
-        with open(session_file, 'r') as f:
-            data = json.load(f)
-            self.assertEqual(len(data["thoughts"]), 1)
-            self.assertEqual(data["thoughts"][0]["thought"], "Test thought")
+        header, thoughts = read_jsonl_records(session_file)
+        self.assertEqual(header["type"], "header")
+        self.assertEqual(header["version"], 2)
+        self.assertEqual(len(thoughts), 1)
+        self.assertEqual(thoughts[0]["thought"], "Test thought")
     
     def test_get_all_thoughts(self):
         """Test getting all thoughts from storage."""
@@ -129,12 +139,12 @@ class TestThoughtStorage(unittest.TestCase):
         
         self.storage.clear_history()
         self.assertEqual(len(self.storage.thought_history), 0)
-        
-        # Check that the session file was updated
-        session_file = Path(self.temp_dir.name) / "current_session.json"
-        with open(session_file, 'r') as f:
-            data = json.load(f)
-            self.assertEqual(len(data["thoughts"]), 0)
+
+        # Check that the session file was rewritten (header only, no thoughts)
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        header, thoughts = read_jsonl_records(session_file)
+        self.assertEqual(header["type"], "header")
+        self.assertEqual(len(thoughts), 0)
     
     def test_export_creates_parent_directory(self):
         """Test exporting a session to a nested directory creates parents."""
@@ -197,13 +207,13 @@ class TestThoughtStorage(unittest.TestCase):
     def test_concurrent_add_clear_disk_matches_memory(self):
         """Concurrent add_thought + clear_history must never leave a stale
         snapshot on disk (regression for the _save_session race)."""
-        session_file = Path(self.temp_dir.name) / "current_session.json"
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
         mismatches = 0
 
         for _ in range(200):
             with tempfile.TemporaryDirectory() as d:
                 storage = ThoughtStorage(d)
-                sfile = Path(d) / "current_session.json"
+                sfile = Path(d) / "current_session.jsonl"
 
                 thought = ThoughtData(
                     thought="Concurrent thought",
@@ -221,8 +231,11 @@ class TestThoughtStorage(unittest.TestCase):
                 t_add.join()
                 t_clear.join()
 
-                with open(sfile, "r", encoding="utf-8") as f:
-                    disk_len = len(json.load(f)["thoughts"])
+                if sfile.exists():
+                    _, disk_thoughts = read_jsonl_records(sfile)
+                    disk_len = len(disk_thoughts)
+                else:
+                    disk_len = 0
 
                 if disk_len != len(storage.thought_history):
                     mismatches += 1
@@ -263,9 +276,9 @@ class TestThoughtStorage(unittest.TestCase):
 
         # Current session unchanged in memory and on disk.
         self.assertEqual(len(self.storage.thought_history), 1)
-        session_file = Path(self.temp_dir.name) / "current_session.json"
-        with open(session_file, "r", encoding="utf-8") as f:
-            self.assertEqual(len(json.load(f)["thoughts"]), 1)
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        _, disk_thoughts = read_jsonl_records(session_file)
+        self.assertEqual(len(disk_thoughts), 1)
 
     # ------------------------------------------------------------------
     # T3: server start recovers from semantically corrupt session file
@@ -344,11 +357,11 @@ class TestThoughtStorage(unittest.TestCase):
         )
         self.storage.add_thought(thought)
 
-        session_file = Path(self.temp_dir.name) / "current_session.json"
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
         before = session_file.read_text(encoding="utf-8")
 
         with self.assertRaises(ValueError):
-            self.storage.export_session("../current_session.json")
+            self.storage.export_session("../current_session.jsonl")
 
         self.assertEqual(session_file.read_text(encoding="utf-8"), before)
 
@@ -410,9 +423,174 @@ class TestThoughtStorage(unittest.TestCase):
         leftovers = list(Path(self.temp_dir.name).glob("*.tmp"))
         self.assertEqual(leftovers, [])
 
-        session_file = Path(self.temp_dir.name) / "current_session.json"
-        with open(session_file, "r", encoding="utf-8") as f:
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        _, disk_thoughts = read_jsonl_records(session_file)
+        self.assertEqual(len(disk_thoughts), 1)
+
+    # ------------------------------------------------------------------
+    # Schema v2: append-only JSONL session format
+    # ------------------------------------------------------------------
+    def _make_thought(self, number, total=3, stage=ThoughtStage.ANALYSIS, needed=True):
+        return ThoughtData(
+            thought=f"Thought {number}",
+            thought_number=number,
+            total_thoughts=total,
+            next_thought_needed=needed,
+            stage=stage,
+        )
+
+    def test_add_thought_appends_single_line(self):
+        """Each add_thought appends exactly one line; the header is written once."""
+        for n in range(1, 4):
+            self.storage.add_thought(self._make_thought(n))
+
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        lines = session_file.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 4)  # header + 3 thoughts
+        self.assertEqual(json.loads(lines[0])["type"], "header")
+
+    def test_jsonl_roundtrip(self):
+        """A fresh storage instance on the same directory loads identical thoughts."""
+        thought = ThoughtData(
+            thought="Roundtrip thought with umlauts äöü",
+            thought_number=1,
+            total_thoughts=2,
+            next_thought_needed=True,
+            stage=ThoughtStage.RESEARCH,
+            tags=["round", "trip"],
+            axioms_used=["axiom1"],
+            assumptions_challenged=["assumption1"],
+        )
+        self.storage.add_thought(thought)
+
+        reloaded = ThoughtStorage(self.temp_dir.name).get_all_thoughts()
+
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded[0].id, thought.id)
+        self.assertEqual(reloaded[0].thought, thought.thought)
+        self.assertEqual(reloaded[0].thought_number, thought.thought_number)
+        self.assertEqual(reloaded[0].total_thoughts, thought.total_thoughts)
+        self.assertEqual(reloaded[0].next_thought_needed, thought.next_thought_needed)
+        self.assertEqual(reloaded[0].stage, thought.stage)
+        self.assertEqual(reloaded[0].tags, thought.tags)
+        self.assertEqual(reloaded[0].axioms_used, thought.axioms_used)
+        self.assertEqual(reloaded[0].assumptions_challenged, thought.assumptions_challenged)
+        self.assertEqual(reloaded[0].timestamp, thought.timestamp)
+
+    def test_migration_from_v1_json(self):
+        """A legacy v1 current_session.json is migrated losslessly to JSONL."""
+        with tempfile.TemporaryDirectory() as d:
+            v1_file = Path(d) / "current_session.json"
+            v1_file.write_text(
+                json.dumps(
+                    {
+                        "thoughts": [
+                            {
+                                "thought": "Legacy thought",
+                                "thoughtNumber": 1,
+                                "totalThoughts": 1,
+                                "nextThoughtNeeded": False,
+                                "stage": "Conclusion",
+                                "timestamp": "2023-01-01T12:00:00",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            storage = ThoughtStorage(d)
+
+            self.assertEqual(len(storage.thought_history), 1)
+            self.assertEqual(storage.thought_history[0].thought, "Legacy thought")
+            self.assertTrue((Path(d) / "current_session.jsonl").exists())
+            self.assertFalse(v1_file.exists())
+            self.assertTrue((Path(d) / "current_session.json.migrated-to-v2").exists())
+
+            # Idempotent: a second start only finds the JSONL file.
+            storage2 = ThoughtStorage(d)
+            self.assertEqual(len(storage2.thought_history), 1)
+
+    def test_truncated_last_line_recovers(self):
+        """A truncated final line (interrupted append) is dropped; the valid
+        prefix of the session survives."""
+        for n in range(1, 3):
+            self.storage.add_thought(self._make_thought(n))
+
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        with open(session_file, "a", encoding="utf-8") as f:
+            f.write('{"type": "thought", "thought": "half writ')  # no newline, cut off
+
+        storage = ThoughtStorage(self.temp_dir.name)  # must not crash
+
+        self.assertEqual(len(storage.thought_history), 2)
+        # No backup created; the file was recoverable.
+        self.assertEqual(list(Path(self.temp_dir.name).glob("current_session.bak.*")), [])
+
+    def test_corrupt_middle_line_backs_up(self):
+        """A corrupt line in the middle invalidates the file: backup + empty session."""
+        for n in range(1, 3):
+            self.storage.add_thought(self._make_thought(n))
+
+        session_file = Path(self.temp_dir.name) / "current_session.jsonl"
+        lines = session_file.read_text(encoding="utf-8").splitlines()
+        lines[1] = "{not json"
+        session_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        storage = ThoughtStorage(self.temp_dir.name)  # must not crash
+
+        self.assertEqual(storage.thought_history, [])
+        self.assertEqual(len(list(Path(self.temp_dir.name).glob("current_session.bak.*"))), 1)
+
+    def test_import_v1_export_still_works(self):
+        """A v0.5.0 JSON export (no 'version' field) is still importable."""
+        export_dir = Path(self.temp_dir.name) / "exports"
+        export_dir.mkdir()
+        legacy_export = export_dir / "legacy_export.json"
+        legacy_export.write_text(
+            json.dumps(
+                {
+                    "thoughts": [
+                        {
+                            "thought": "Exported thought",
+                            "thoughtNumber": 1,
+                            "totalThoughts": 1,
+                            "nextThoughtNeeded": False,
+                            "stage": "Synthesis",
+                        }
+                    ],
+                    "lastUpdated": "2025-01-01T00:00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        self.storage.import_session(str(legacy_export))
+
+        self.assertEqual(len(self.storage.thought_history), 1)
+        self.assertEqual(self.storage.thought_history[0].thought, "Exported thought")
+
+    def test_import_rejects_unknown_newer_version(self):
+        """An export claiming a newer schema version is rejected."""
+        export_dir = Path(self.temp_dir.name) / "exports"
+        export_dir.mkdir()
+        future_export = export_dir / "future.json"
+        future_export.write_text(
+            json.dumps({"version": 99, "thoughts": []}), encoding="utf-8"
+        )
+
+        with self.assertRaises(ValueError):
+            self.storage.import_session(str(future_export))
+
+    def test_export_includes_schema_version(self):
+        """Exports carry the top-level schema version field."""
+        self.storage.add_thought(self._make_thought(1, total=1, needed=False))
+        self.storage.export_session("versioned.json")
+
+        export_file = Path(self.temp_dir.name) / "exports" / "versioned.json"
+        with open(export_file, "r", encoding="utf-8") as f:
             data = json.load(f)
+        self.assertEqual(data["version"], 2)
         self.assertEqual(len(data["thoughts"]), 1)
 
 


### PR DESCRIPTION
## Summary

This PR delivers **v0.6.0**: thought revisions & branching, a new append-only JSONL session format (schema v2) with automatic v1 migration, the package rename required for the PyPI release, several data-loss and information-leak fixes in import/export, and CI/release automation.

Test suite grows from 27 to **57 tests** (no test deleted); `mypy` is clean under the strict config. Everything was verified end-to-end against the real MCP tools (migration → revision → branch → summary → export/clear/import roundtrip → traversal rejection).

---

## 1. Package rename: `sequential-thinking` → `mcp-sequential-thinking`

The PyPI name `sequential-thinking` is occupied by a third-party fork, so the project is renamed to `mcp-sequential-thinking` (matching the repo, the console script, and the import package — those are unchanged). Version bumped to `0.6.0`.

## 2. Revisions & branching (core feature)

`process_thought` gains four optional parameters:

| Parameter | Type | Meaning |
|---|---|---|
| `is_revision` | bool | This thought revises an earlier one |
| `revises_thought_number` | int | Which thought is being revised (required with `is_revision`) |
| `branch_from_thought` | int | Fork point for an alternative line of reasoning |
| `branch_id` | str | Branch identifier, `[A-Za-z0-9_-]`, max 64 chars |

Cross-field validation (pydantic `model_validator`): revision flag and target imply each other, targets must reference an earlier thought (`>= 1`, `< thought_number`), `branch_id` requires a fork point, and revision/branch are mutually exclusive.

Analysis is revision/branch-aware:

- `analyze_thought` reports `isRevision`, `revisedThought`, `branchId`, plus a `revisionOf` snippet of the revised thought.
- `generate_summary` gains a `branches` object (`{branch_id: {fromThought, thoughtCount}}`), a `revisionCount`, and flags timeline entries.
- **Progress metrics count mainline thoughts only** — previously a 5-thought session with 3 revisions would have reported 160% completion.

Serialization uses camelCase and omits fields at their defaults, so pre-existing v2 files stay readable — no schema bump needed.

## 3. Append-only JSONL session format (schema v2)

Previously every `add_thought` re-serialized the entire history — O(n²) over a session, plus lock-file I/O per call. Now:

- Session lives in `current_session.jsonl`: a header record (`{"type": "header", "version": 2, ...}`) followed by one thought record per line.
- `add_thought` appends a single fsynced line — **O(1) per call**, and the file doubles as an audit trail.
- `clear_history` / `import_session` atomically rewrite the file (tmp + fsync + `os.replace`).
- **Crash recovery:** a truncated final line (interrupted append) is dropped with a warning; corruption elsewhere still backs the file up and recovers with an empty session.
- **Migration:** a legacy v1 `current_session.json` is migrated losslessly on first start and renamed to `current_session.json.migrated-to-v2` (idempotent — second start only finds the JSONL).
- JSON **exports** stay JSON (portable, human-readable) and gain a top-level `"version": 2`. v0.5.x exports without the field remain importable; unknown newer versions are rejected with a clear error.

## 4. Import/export hardening (data loss, path leaks)

- **`import_session` data-loss fix:** a valid JSON file *without* a `thoughts` key (e.g. pointing at the wrong file) used to silently import an empty list, wipe the active session, and persist that. It now raises `KeyError` and leaves session + source file untouched. Same for a **nonexistent** file (now `FileNotFoundError` instead of silently clearing the session).
- **Export clobber fix (breaking):** exports/imports are confined to a new `exports/` subdirectory of the storage dir. Previously `export_session("current_session.json")` could overwrite the active session and its derived lock file collided with `current_session.lock`. Relative paths now resolve under `~/.mcp_sequential_thinking/exports/`.
- **Path leak fix:** the `ValueError` returned to the MCP client on a rejected path no longer contains the resolved absolute base path (which leaked the user's home directory). The full path is still logged server-side.

## 5. CI, release automation, security policy

- **CI:** pytest + mypy matrix on `ubuntu-latest`/`windows-latest` × Python 3.10/3.12. Windows is deliberately in the matrix (portalocker behaves differently there; a large share of Claude Desktop users are on Windows).
- **Release:** publishing to PyPI via **Trusted Publishing** on GitHub release. All actions pinned to release commit SHAs (`checkout` v5.0.0, `setup-python` v5.6.0, `gh-action-pypi-publish` v1.14.0).
- Dependabot (pip + github-actions, weekly) and `SECURITY.md` with private disclosure contact.

## 6. Docs

README overhauled: revisions & branching documented with examples, JSONL persistence + migration notes, `exports/` semantics, PyPI/uvx install instructions, and a factual comparison to the official sequential-thinking server (persistence, stages, analysis). CHANGELOG follows Keep-a-Changelog for the 0.6.0 section.

---

## ⚠️ Breaking changes

1. **Export/import paths** are now confined to the `exports/` subdirectory; relative paths resolve there instead of the storage root.
2. **Session file format** changed to JSONL (`current_session.jsonl`). Migration from v1 is automatic and lossless.
3. **Package name** on PyPI is `mcp-sequential-thinking`.

## 🔑 Maintainer action required before the first release

The release workflow uses PyPI Trusted Publishing, which needs a one-time setup on pypi.org (this cannot be automated):

1. On pypi.org → *Publishing* → add a **Trusted Publisher** for project `mcp-sequential-thinking`:
   - Repository: `arben-adm/mcp-sequential-thinking`
   - Workflow: `release.yml`
   - Environment: `pypi`
2. Create the `pypi` environment in the GitHub repo settings (optionally with protection rules).

## Test plan

- [x] 57 tests pass on Python 3.10 and 3.12 (Linux); Windows covered by the new CI matrix on this PR
- [x] `mypy mcp_sequential_thinking/` clean on 3.10 and 3.12
- [x] No existing test deleted; only format expectations updated, all semantic assertions (traversal, locking, data preservation) kept
- [x] v1 `current_session.json` from v0.5.0 migrates losslessly on first start (test + live run)
- [x] v0.5.0 JSON export imports successfully (test + live run)
- [x] End-to-end run of all five MCP tools including revision/branch parameters and traversal rejection
